### PR TITLE
fix: update GitHub Actions to use new output format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,10 @@ jobs:
         id: check_version
         run: |
           if [ "$(echo ${{ env.CURRENT_VERSION }} ${{ env.LATEST_TAG }} | awk '{print ($1 > $2)}')" = "1" ]; then
-            echo "::set-output name=should_publish::true"
+            echo "should_publish=true" >> $GITHUB_OUTPUT
           else
             echo "Version has not been bumped. Skipping publish."
-            echo "::set-output name=should_publish::false"
+            echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish to PyPI


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions workflow to use the new output format instead of the deprecated `::set-output` syntax.

## Changes
- Replace `echo "::set-output name=should_publish::true"` with `echo "should_publish=true" >> $GITHUB_OUTPUT`
- Replace `echo "::set-output name=should_publish::false"` with `echo "should_publish=false" >> $GITHUB_OUTPUT`

## Why this change?
GitHub has deprecated the `set-output` command in favor of environment files. This ensures our workflows will continue to work with future GitHub Actions runner versions.

## Reference
This is the easiest change from the DevOps improvements documented in `docs/devops_improvements.md`.

## Testing
- The workflow syntax has been updated
- Pre-commit hooks passed successfully  
- No functional changes to the publishing logic