### PR TITLE
feat: add Python dependency monitoring to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
    directory: "/"
    schedule:
      interval: weekly
+ - package-ecosystem: "pip"
+   directory: "/"
+   schedule:
+     interval: weekly
+   open-pull-requests-limit: 5


### PR DESCRIPTION
## Description
This PR adds Python dependency monitoring to our Dependabot configuration, enabling automated dependency updates for Python packages.

## Changes
- Added `pip` package ecosystem to `.github/dependabot.yml`
- Configured weekly update schedule for Python dependencies
- Set `open-pull-requests-limit: 5` to avoid PR spam

## Benefits
- **Security**: Automated security updates for vulnerable dependencies
- **Maintenance**: Stay up-to-date with bug fixes and improvements
- **Visibility**: Clear tracking of dependency updates through PRs
- **Control**: Limited to 5 open PRs at a time to avoid overwhelming the team

## Testing
- The YAML syntax is valid
- Configuration follows Dependabot best practices
- No breaking changes to existing devcontainer monitoring

## Next Steps
Once merged, Dependabot will start scanning Python dependencies weekly and create PRs for any available updates.