### PR TITLE
fix: use Python packaging library for robust version comparison

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,15 @@ jobs:
       - name: Check if version bump is required
         id: check_version
         run: |
-          if [ "$(echo ${{ env.CURRENT_VERSION }} ${{ env.LATEST_TAG }} | awk '{print ($1 > $2)}')" = "1" ]; then
+          CURRENT_VERSION=${{ env.CURRENT_VERSION }}
+          LATEST_TAG=${{ env.LATEST_TAG }}
+
+          # Use Python for robust version comparison
+          if python -c "from packaging.version import Version; exit(0) if Version('$CURRENT_VERSION') > Version('$LATEST_TAG') else exit(1)"; then
+            echo "Version $CURRENT_VERSION > $LATEST_TAG. Proceeding with publish."
             echo "should_publish=true" >> $GITHUB_OUTPUT
           else
-            echo "Version has not been bumped. Skipping publish."
+            echo "Version $CURRENT_VERSION <= $LATEST_TAG. Skipping publish."
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Description
This PR fixes the version comparison logic in the publish workflow by replacing the awk-based string comparison with Python's  for proper semantic versioning support.

## Problem
The current awk-based comparison treats versions as strings, which leads to incorrect comparisons:
- `1.10.0` is considered less than `1.9.0` (string comparison)
- Pre-release versions like `1.0.0-alpha` or `2.0.0rc1` aren't handled correctly
- Other semantic versioning edge cases fail

## Solution
Use Python's `packaging.version.Version` which correctly implements semantic versioning comparison according to PEP 440.

## Changes
- Replace awk comparison with Python script using `packaging.version.Version`
- Add clear output messages for debugging
- Store versions in variables for cleaner code

## Example
**Before (incorrect):**
```bash
# This would incorrectly say 1.10.0 < 1.9.0
if [ "$(echo 1.10.0 1.9.0 | awk '{print ($1 > $2)}')" = "1" ]; then
```

**After (correct):**
```python
# This correctly identifies 1.10.0 > 1.9.0
if python -c "from packaging.version import Version; exit(0) if Version('1.10.0') > Version('1.9.0') else exit(1)"; then
```

## Testing
- The Python packaging library is included by default in the GitHub Actions Python environment
- The logic has been tested with various version formats
- Clear output messages help with debugging

This fix prevents publishing failures when version numbers don't follow simple numeric patterns.