### PR TITLE
feat: migrate to OIDC trusted publishing for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     if: github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication with PyPI
 
     steps:
       - name: Checkout code
@@ -56,12 +58,15 @@ jobs:
             echo "should_publish=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Build package
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: poetry build
+
       - name: Publish to PyPI
         if: steps.check_version.outputs.should_publish == 'true'
-        run: |
-          poetry publish --build --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
 
       - name: Create new tag
         if: steps.check_version.outputs.should_publish == 'true'


### PR DESCRIPTION
## Description
This PR migrates from API token authentication to OIDC (OpenID Connect) trusted publishing for PyPI releases, significantly improving security by eliminating the need to store and manage long-lived API tokens.

## Changes
- Add `id-token: write` permission to the publish job for OIDC authentication
- Replace Poetry's direct publish command with the official `pypa/gh-action-pypi-publish` action
- Split build and publish into separate steps for better visibility
- Remove dependency on `PYPI_API_TOKEN` secret

## Benefits
1. **Enhanced Security**: No more long-lived API tokens that could be compromised
2. **Simplified Management**: No need to rotate or manage PyPI tokens
3. **Better Auditability**: Each publish action is tied to a specific GitHub Actions run
4. **Official Support**: Uses PyPA's official GitHub Action for publishing

## Setup Required
Before merging this PR, you need to configure PyPI to trust this GitHub repository:

1. Go to https://pypi.org/manage/account/publishing/
2. Add a new trusted publisher for your project with these settings:
   - **Owner**: Leikaab
   - **Repository**: crudclient
   - **Workflow name**: publish.yml
   - **Environment**: (leave blank)

## Testing
The workflow will only attempt to publish when:
1. Tests pass successfully
2. Running on the main branch
3. Version is greater than the latest published version

The OIDC token is only generated during the actual workflow run, making it impossible to test locally.

## Breaking Changes
None - this is a backend change that doesn't affect package users.

## Related Documentation
- [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)
- [GitHub OIDC for PyPI](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)