### PR TITLE
feat: add pre-release support to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    if: github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main'
+    if: github.event.workflow_run.conclusion == 'success' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC authentication with PyPI
@@ -53,6 +53,15 @@ jobs:
           if python -c "from packaging.version import Version; exit(0) if Version('$CURRENT_VERSION') > Version('$LATEST_TAG') else exit(1)"; then
             echo "Version $CURRENT_VERSION > $LATEST_TAG. Proceeding with publish."
             echo "should_publish=true" >> $GITHUB_OUTPUT
+
+            # Check if this is a pre-release version
+            if python -c "from packaging.version import Version; exit(0) if Version('$CURRENT_VERSION').is_prerelease else exit(1)"; then
+              echo "Detected pre-release version: $CURRENT_VERSION"
+              echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            else
+              echo "Detected stable version: $CURRENT_VERSION"
+              echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "Version $CURRENT_VERSION <= $LATEST_TAG. Skipping publish."
             echo "should_publish=false" >> $GITHUB_OUTPUT
@@ -62,10 +71,17 @@ jobs:
         if: steps.check_version.outputs.should_publish == 'true'
         run: poetry build
 
-      - name: Publish to PyPI
-        if: steps.check_version.outputs.should_publish == 'true'
+      - name: Publish to PyPI (stable)
+        if: steps.check_version.outputs.should_publish == 'true' && steps.check_version.outputs.is_prerelease == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verbose: true
+
+      - name: Publish to TestPyPI (pre-release)
+        if: steps.check_version.outputs.should_publish == 'true' && steps.check_version.outputs.is_prerelease == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
           verbose: true
 
       - name: Create new tag


### PR DESCRIPTION
## Description
Adds support for publishing pre-release versions to TestPyPI while stable releases go to PyPI.

## Changes
- Enable publishing from both main and develop branches
- Detect pre-release versions using packaging.version.is_prerelease
- Split publish steps: stable releases to PyPI, pre-releases to TestPyPI
- Add version type detection output for workflow clarity

## Benefits
- Test pre-release versions on TestPyPI before stable releases
- Dual-track release process for better version management
- Automatic detection of version type (stable vs pre-release)