### PR TITLE
feat: add act to DevContainer for local GitHub Actions testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,11 @@ RUN poetry install --no-interaction --no-ansi --with dev --no-root
 # Add the project's .venv to PATH for all users
 ENV PATH="/workspace/.venv/bin:$PATH"
 
+# Install act for local GitHub Actions testing
+RUN curl https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
+    mv bin/act /usr/local/bin/act && \
+    rm -rf bin
+
 # Create .vscode-server directory structure and set proper ownership
 # This prevents permission issues when VS Code tries to create these directories
 RUN mkdir -p /home/vscode/.vscode-server/data/User/globalStorage && \

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -59,4 +59,13 @@ else
     echo "Poetry could not be found"
 fi
 
+# Verify act installation
+if command -v act &> /dev/null; then
+    echo "✓ act is installed (version: $(act --version))"
+    echo "  You can now test GitHub Actions locally with: act"
+    echo "  Example: act -j test"
+else
+    echo "✗ act installation failed"
+fi
+
 echo "Development environment setup complete!"


### PR DESCRIPTION
## Description
Adds act to the DevContainer setup to enable local testing of GitHub Actions workflows.

## Changes
- Install act in Dockerfile using the official installation script
- Add verification step in postCreateCommand.sh to confirm act installation
- Display act version and usage example on container startup

## Benefits
- Test GitHub Actions workflows locally before pushing
- Reduce CI/CD debugging cycles
- Improve developer experience with faster feedback loops

## Usage
After rebuilding the DevContainer, you can test workflows locally:
```bash
# List available workflows
act -l

# Run a specific job
act -j test

# Run with specific event
act push
```

This helps catch workflow issues early without consuming GitHub Actions minutes.