### PR TITLE
Improve CRUD create operation test

### DIFF
--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -168,10 +168,8 @@ class TestResourceGroupAsCrud:
         result = group.create(data=data)
 
         # Assert
-        # Check that the client was called with the correct path
-        mock_client.post.assert_called_once()
-        args, kwargs = mock_client.post.call_args
-        assert args[0] == "test-group"
+        # Check that the client was called with the correct path and payload
+        mock_client.post.assert_called_once_with("test-group", json=data, params=None)
         assert isinstance(result, ResourceTestModel)
         assert result.id == 1
         assert result.name == "New Resource"


### PR DESCRIPTION
## Summary
- ensure CRUD `create` test checks request payload and parameters

## Testing
- `isort .`
- `black .`
- `poetry run flake8`
- `poetry run pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c290ee488332b31e7f3013b9f1d9