### PR TITLE
Improve retry helper test coverage

### DIFF
--- a/tests/unit/client/test_client_data.py
+++ b/tests/unit/client/test_client_data.py
@@ -175,3 +175,17 @@ class TestClient:
 
         assert "400" in str(excinfo.value)
         assert "Bad Request" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "method,url,kwargs,response,expected",
+        [
+            (123, "https://example.com", {}, requests.Response(), "method must be a string"),
+            ("GET", 123, {}, requests.Response(), "url must be a string"),
+            ("GET", "https://example.com", None, requests.Response(), "kwargs must be a dictionary"),
+            ("GET", "https://example.com", {}, object(), "response must be a requests.Response object"),
+        ],
+    )
+    def test_maybe_retry_after_403_type_errors(self, client, method, url, kwargs, response, expected) -> None:
+        """_maybe_retry_after_403 should validate argument types."""
+        with pytest.raises(TypeError, match=expected):
+            client._maybe_retry_after_403(method, url, kwargs, response)  # type: ignore[arg-type]

--- a/tests/unit/client/test_client_data.py
+++ b/tests/unit/client/test_client_data.py
@@ -189,3 +189,31 @@ class TestClient:
         """_maybe_retry_after_403 should validate argument types."""
         with pytest.raises(TypeError, match=expected):
             client._maybe_retry_after_403(method, url, kwargs, response)
+
+    def test_maybe_retry_after_403_calls_setup_auth(self, client, mocker) -> None:
+        """_maybe_retry_after_403 should refresh auth before retrying."""
+        client.config.should_retry_on_403 = lambda: True
+        mocker.patch.object(client.config, "handle_403_retry")
+        setup_auth = mocker.patch.object(client, "_setup_auth")
+
+        retried_response = requests.Response()
+        retried_response.status_code = 200
+        mocker.patch.object(client._session, "request", return_value=retried_response)
+
+        original_response = requests.Response()
+        original_response.status_code = 403
+
+        result = client._maybe_retry_after_403(
+            "GET",
+            "https://example.com",
+            {"p": "v"},
+            original_response,
+        )
+
+        setup_auth.assert_called_once_with()
+        client._session.request.assert_called_once_with(
+            "GET",
+            "https://example.com",
+            p="v",
+        )
+        assert result is retried_response

--- a/tests/unit/client/test_client_data.py
+++ b/tests/unit/client/test_client_data.py
@@ -188,4 +188,4 @@ class TestClient:
     def test_maybe_retry_after_403_type_errors(self, client, method, url, kwargs, response, expected) -> None:
         """_maybe_retry_after_403 should validate argument types."""
         with pytest.raises(TypeError, match=expected):
-            client._maybe_retry_after_403(method, url, kwargs, response)  # type: ignore[arg-type]
+            client._maybe_retry_after_403(method, url, kwargs, response)


### PR DESCRIPTION
## Summary
- add type validation checks for `_maybe_retry_after_403`

## Testing
- `pytest tests/unit/client/test_client_data.py::TestClient::test_maybe_retry_after_403_type_errors -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c28f4d0c8332829de9823b99e249