### PR TITLE
Improve close test

### DIFF
--- a/tests/unit/client/test_client_base.py
+++ b/tests/unit/client/test_client_base.py
@@ -272,7 +272,7 @@ class TestClient:
         with pytest.raises(TypeError, match="files must be a dictionary or None"):
             client.patch("/users/1", files=invalid_files)  # type: ignore # pylance-only
 
-    def test_close(self, client):
+    def test_close(self, client, mocker):
         """
         GIVEN an initialized client with an active session
         WHEN the client's close method is called
@@ -280,9 +280,14 @@ class TestClient:
         """
         # GIVEN - client fixture provides this
 
+        # GIVEN
+        session = client.session  # ensure property is attached
+        close_mock = mocker.patch.object(session, "close")
+
         # WHEN
         client.close()
 
         # THEN
-        # We assert that the session manager's is_closed attribute is set to True
+        close_mock.assert_called_once()
         assert client.http_client.session_manager.is_closed
+        assert session.is_closed


### PR DESCRIPTION
## Summary
- enhance client close behavior test

## Testing
- `isort --check tests/unit/client/test_client_base.py`
- `black --check tests/unit/client/test_client_base.py`
- `flake8 tests/unit/client/test_client_base.py`
- `pytest tests/unit/client/test_client_base.py::TestClient::test_close -q`


------
https://chatgpt.com/codex/tasks/task_e_6842c28d2fcc8332be69cc056ab2dac9