### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ class OneflowAPI(API):
 ```python
 from api_example import CustomConfig, OneflowAPI
 
-def main()
+def main():
     config = CustomConfig()
     api = OneflowAPI(client_config=config)
     users = api.users.list()


### PR DESCRIPTION
## Summary
- fix function definition in README usage example

## Testing
- `pytest -k nothing -m ""` *(fails: ModuleNotFoundError: No module named 'xdist')*

------
https://chatgpt.com/codex/tasks/task_e_6842c7461e988332afc30f6db31e17c8