### PR TITLE
Fix small README errors

### DIFF
--- a/AUTH_STRATEGIES.md
+++ b/AUTH_STRATEGIES.md
@@ -39,7 +39,7 @@ auth_strategy = BearerAuth(access_token="your_access_token")
 # Use it in your client configuration
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 client = Client(config)
 ```
@@ -58,7 +58,7 @@ auth_strategy = BasicAuth(username="your_username", password="your_password")
 # Use it in your client configuration
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 client = Client(config)
 ```
@@ -86,7 +86,7 @@ auth_strategy = ApiKeyAuth(
 # Use it in your client configuration
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 client = Client(config)
 ```
@@ -111,7 +111,7 @@ auth_strategy = CustomAuth(apply_auth=apply_custom_auth)
 # Use it in your client configuration
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 client = Client(config)
 ```
@@ -135,7 +135,7 @@ config = ClientConfig(
 auth_strategy = create_auth_strategy("bearer", "your_token")  # Uses access_token internally
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ class CustomConfig(ClientConfig):
             timeout=timeout,
             retries=retries,
             # Create a custom API key authentication strategy
-            auth=ApiKeyAuth(api_key=api_key, header_name="x-myapi-api-token")
+            auth_strategy=ApiKeyAuth(api_key=api_key, header_name="x-myapi-api-token")
         )
 
 
@@ -133,7 +133,7 @@ class OneflowAPI(API):
 ```python
 from api_example import CustomConfig, OneflowAPI
 
-def main()
+def main():
     config = CustomConfig()
     api = OneflowAPI(client_config=config)
     users = api.users.list()
@@ -211,7 +211,7 @@ user_posts = api.users.posts.list(parent_id=1)  # GET /users/1/posts
 
 ## Logging
 
-The library has standard logging that can be hooked into using get.logger
+The library has standard logging that can be hooked into using `logging.getLogger`
 
 <details>
   <summary>Code example</summary>
@@ -287,7 +287,7 @@ This project employs `pytest` for local testing and cd/ci, and also coverage to 
   To run the tests and generate a coverage report, simply use the following commands within the container:
 
   ```bash
-  pytest --cov=your_package_name --cov-report=html
+  pytest --cov=crudclient --cov-report=html
   ```
 
   This command will execute all tests and generate an HTML report that you can view in your browser, providing a visual representation of the code coverage.

--- a/crudclient/auth.py
+++ b/crudclient/auth.py
@@ -42,7 +42,7 @@ api_auth = ApiKeyAuth(
 # Use it in your client configuration
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth=auth_strategy
+    auth_strategy=auth_strategy
 )
 client = Client(config)
 

--- a/crudclient/client.py
+++ b/crudclient/client.py
@@ -47,7 +47,7 @@ class Client:
         ----------
         config : Union[ClientConfig, Dict[str, Any]]
             Configuration for the client. Can be a ClientConfig object or a dictionary
-            containing parameters like `base_url`, `auth`, `timeout`, and logging settings
+            containing parameters like `base_url`, `auth_strategy`, `timeout`, and logging settings
             (`log_request_body`, `log_response_body`).
 
         Raises


### PR DESCRIPTION
## Summary
- correct misnamed auth parameter in README
- fix minor typos and placeholder values
- fix auth doc examples

## Testing
- `pre-commit run --files AUTH_STRATEGIES.md crudclient/auth.py crudclient/client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xdist')*

------
https://chatgpt.com/codex/tasks/task_e_6842c74b68ec833285b192d5eb01a3d8