### PR TITLE
Fix documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ This project employs `pytest` for local testing and cd/ci, and also coverage to 
   Pre-commit hooks are executed before each commit is finalized. These hooks ensure that the code adheres to the project's style guidelines and passes initial validation checks. The following tools are configured to run as part of the pre-commit hooks:
 
   - **isort**: Ensures that imports are properly sorted according to the project's style.
-  - **black**: Formats the code to comply with the `black` code style, with a line length of 120 characters.
+  - **black**: Formats the code to comply with the `black` code style, with a line length of 150 characters (see `pyproject.toml`).
   - **flake8**: Runs linting checks to identify any potential issues in the code, excluding `setup.py`.
   - **mypy**: Performs static type checking to ensure type safety in the codebase.
   - **pytest**: Runs the unit tests to verify that the code changes do not break existing functionality.

--- a/crudclient/__init__.py
+++ b/crudclient/__init__.py
@@ -28,7 +28,7 @@ class MyAPI(API):
 # Create a configuration with bearer token authentication
 config = ClientConfig(
     hostname="https://api.example.com",
-    auth_strategy=BearerAuth(token="your_token")
+    auth_strategy=BearerAuth(access_token="your_token")
 )
 
 # Initialize the API client


### PR DESCRIPTION
## Summary
- fix BearerAuth example in `__init__.py`
- document correct black line length in README

## Testing
- `pytest tests/unit/test_redaction.py::test_log_response_body_redaction_simple -q`

------
https://chatgpt.com/codex/tasks/task_e_6843623db3dc833297fc2933fc322c28