### PR TITLE
Improve ResponseHandler unit test with log verification

### DIFF
--- a/tests/unit/http/test_response_handler.py
+++ b/tests/unit/http/test_response_handler.py
@@ -1,4 +1,5 @@
 # No need for json import directly
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +10,7 @@ from crudclient.exceptions import ResponseParsingError
 from crudclient.http.response import ResponseHandler
 
 
-def test_response_parsing_error(mocker):
+def test_response_parsing_error(mocker, caplog: pytest.LogCaptureFixture) -> None:
     """Test that ResponseParsingError is raised for invalid JSON responses."""
     # Arrange
     handler = ResponseHandler()
@@ -25,6 +26,10 @@ def test_response_parsing_error(mocker):
     # Mock the .json() method on the instance to raise the correct exception
     mock_response.json.side_effect = requests_exceptions.JSONDecodeError("Expecting value", invalid_json_text, 0)
     mock_response.status_code = 200  # Assume a successful status code
+    mock_response.ok = True
+    mock_response.raise_for_status = mocker.Mock()
+
+    caplog.set_level(logging.ERROR, logger="crudclient.http.response")
 
     # Act & Assert
     # We expect ResponseParsingError to be raised by the handler's wrapper
@@ -37,7 +42,17 @@ def test_response_parsing_error(mocker):
     # Assert exception attributes
     # Check the original exception type (requests wraps the standard json.JSONDecodeError)
     assert isinstance(excinfo.value.original_exception, requests_exceptions.JSONDecodeError)
-    assert excinfo.value.response is not None  # Check response is not None
-    assert excinfo.value.response is mock_response  # Check it's the same object
+    assert excinfo.value.__cause__ is excinfo.value.original_exception
+    assert excinfo.value.response is not None
+    assert excinfo.value.response is mock_response
     assert excinfo.value.response.status_code == 200
     assert excinfo.value.response.text == invalid_json_text
+    assert excinfo.value.args[0] == f"Failed to decode JSON response from {mock_response.url}"
+
+    assert any(
+        record.levelno == logging.ERROR
+        and "Failed to parse JSON response" in record.message
+        and str(mock_response.status_code) in record.message
+        and mock_response.url in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- enhance ResponseHandler test to verify logged errors
- assert exception message and chaining
- set up mock response more realistically

## Testing
- `isort tests/unit/http/test_response_handler.py`
- `black tests/unit/http/test_response_handler.py`
- `flake8 tests/unit/http/test_response_handler.py`
- `pytest -q tests/unit/http/test_response_handler.py::test_response_parsing_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68436202d2088332b451d159aa3cb735