### PR TITLE
Improve configuration tests

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -146,3 +146,11 @@ class TestClientConfig:
 
         with pytest.raises(TypeError):
             ClientConfig.merge_configs("not a config", base_config)  # type: ignore
+
+    def test_get_config_errors(self) -> None:
+        """Validate get_config_errors reports missing hostname."""
+        cfg = ClientConfig()
+        assert cfg.get_config_errors() == {"hostname": "hostname is required"}
+
+        cfg = ClientConfig(hostname="https://example.com")
+        assert cfg.get_config_errors() == {}


### PR DESCRIPTION
## Summary
- enhance coverage for ClientConfig
- ensure get_config_errors correctly reports missing hostname

## Testing
- `pytest -q tests/unit/test_config.py::TestClientConfig::test_get_config_errors`
- `pytest -q tests/unit/test_config.py`
- `isort tests/unit/test_config.py`
- `black tests/unit/test_config.py`
- `flake8 tests/unit/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_684361fb34048332b93361771149cb56