### PR TITLE
Fix handle leak in ratelimit lock

### DIFF
--- a/crudclient/ratelimit/storage/file_json.py
+++ b/crudclient/ratelimit/storage/file_json.py
@@ -85,6 +85,10 @@ class FileJSONBackend(StorageBackend):
                 return
             except portalocker.LockException:
                 # Lock is held by another process/thread
+                try:
+                    handle.close()
+                except Exception:
+                    pass
                 if attempt == 0:
                     logger.debug(f"Lock busy, waiting... (thread: {threading.current_thread().name})")
                 attempt += 1


### PR DESCRIPTION
## Summary
- close file handle when lock acquisition fails

## Testing
- `flake8 crudclient/ratelimit/storage/file_json.py`
- `pytest tests/unit/test_ratelimit_simple.py::TestRateLimiterSimple::test_basic_rate_limiting -q`
- `pytest tests/unit/test_ratelimit_simple.py -q`
- `pytest tests/unit/test_ratelimit_parallel.py::TestRateLimiterParallel::test_parallel_rate_limiting -q`


------
https://chatgpt.com/codex/tasks/task_e_6843b5be12b08332bb006948d396074d