### PR TITLE
Fix list index support in path based strategy

### DIFF
--- a/crudclient/response_strategies/README.md
+++ b/crudclient/response_strategies/README.md
@@ -34,8 +34,8 @@ This strategy extends the conversion logic by allowing data extraction from nest
     *   `single_item_path: Optional[str]`: A dot-notation path (e.g., `"result.data"`) to locate the single item data within the response.
     *   `list_item_path: Optional[str]`: A dot-notation path to locate the list data within the response.
     *   `pre_transform: Optional[ResponseTransformer]`: A callable function to modify the raw response data *before* path extraction or model conversion.
-*   **`convert_single`**: Prepares the data (handles `dict`, `str`, `bytes`), applies the `pre_transform` if provided, extracts the relevant part using `single_item_path` if provided, and then converts it using the `datamodel` (or returns the extracted `JSONDict` if no model).
-*   **`convert_list`**: Prepares the data, applies `pre_transform`. If an `api_response_model` is provided and the data is a dictionary, it attempts to parse using that model. Otherwise, it extracts the list data using `list_item_path` if provided. Finally, it converts list items using the `datamodel` if specified, or returns the extracted `JSONList`.
+*   **`convert_single`**: Prepares the data (handles `dict`, `str`, `bytes`), applies the `pre_transform` if provided, extracts the relevant part using `single_item_path` if provided, and then converts it using the `datamodel` (or returns the extracted `JSONDict` if no model). Path segments may include numeric indices to access list elements (for example `"results.0.item"`).
+*   **`convert_list`**: Prepares the data, applies `pre_transform`. If an `api_response_model` is provided and the data is a dictionary, it attempts to parse using that model. Otherwise, it extracts the list data using `list_item_path` if provided. Numeric indices in the path are also supported. Finally, it converts list items using the `datamodel` if specified, or returns the extracted `JSONList`.
 
 ## Supporting Types
 

--- a/crudclient/response_strategies/path_based.py
+++ b/crudclient/response_strategies/path_based.py
@@ -54,11 +54,23 @@ class PathBasedResponseModelStrategy(ResponseModelStrategy[T]):
         if not path:
             return data
 
-        current = data
+        current: Any = data
         for part in path.split("."):
-            if not isinstance(current, dict) or part not in current:
-                raise ValueError(f"Could not find '{part}' in path '{path}' in response data")
-            current = current[part]
+            if isinstance(current, list):
+                try:
+                    index = int(part)
+                except ValueError:
+                    raise ValueError(f"Expected integer index in path '{path}', got '{part}'")
+                try:
+                    current = current[index]
+                except IndexError:
+                    raise ValueError(f"Index {index} out of range in path '{path}'")
+            elif isinstance(current, dict):
+                if part not in current:
+                    raise ValueError(f"Could not find '{part}' in path '{path}' in response data")
+                current = current[part]
+            else:
+                raise ValueError(f"Unable to traverse into '{part}' from type {type(current)} while processing path '{path}'")
 
         return current
 


### PR DESCRIPTION
## Summary
- allow numeric indices in `_extract_by_path`
- document that list indices are supported

## Testing
- `pytest tests/unit/response_strategies/test_response_strategies.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b5cca5d88332946241fe5c2cd85b