### PR TITLE
Clarify Crud.list returning ApiResponse

### DIFF
--- a/crudclient/crud/README.md
+++ b/crudclient/crud/README.md
@@ -78,7 +78,12 @@ user_crud = UserCrud(client=client)
 # --- Perform Operations ---
 
 # List users
-all_users: list[User] = user_crud.list()
+user_response: ApiResponse[User] = user_crud.list()
+all_users: list[User] = user_response.data
+
+# ``list`` may return an ``ApiResponse`` wrapper when a response model is
+# configured. Access the ``data``/``values`` attribute to get the list of
+# ``User`` instances instead of overriding the method to return a raw list.
 
 # Create a new user
 new_user_data = {"name": "Jane Doe", "email": "jane.doe@example.com"}

--- a/crudclient/crud/operations.py
+++ b/crudclient/crud/operations.py
@@ -27,8 +27,14 @@ logger = logging.getLogger(__name__)
 
 
 def list_operation(self: "Crud", parent_id: Optional[str] = None, params: Optional[JSONDict] = None) -> Union[JSONList, TypingList[T], ApiResponse]:
-    """
-    Retrieve a list of resources.
+    """Retrieve a list of resources.
+
+    The returned value depends on the configured response strategy. When an
+    ``_api_response_model`` is set (or the active strategy produces one), the
+    method returns an :class:`ApiResponse` instance containing the list in its
+    ``data``/``values`` attribute along with any metadata. Callers expecting only
+    the raw list should access ``.data`` on the returned object instead of
+    overriding this method.
 
     Parameters
     ----------
@@ -40,7 +46,7 @@ def list_operation(self: "Crud", parent_id: Optional[str] = None, params: Option
     Returns
     -------
     Union[JSONList, List[T], ApiResponse]
-        List of resources.
+        Validated list data or the full ``ApiResponse`` wrapper.
 
     Raises
     ------

--- a/docs/resource_groups.md
+++ b/docs/resource_groups.md
@@ -165,7 +165,10 @@ With this configuration, you can perform operations directly on the group:
 
 ```python
 # Get a list of ledgers
-ledgers = api.ledger.list()
+ledger_response = api.ledger.list()
+ledgers = ledger_response.values
+# ``list`` returns the full API response when a response model is defined.
+# Use the ``values`` or ``data`` attribute to access the list itself.
 
 # Get a specific ledger
 ledger = api.ledger.read(resource_id=123)
@@ -268,7 +271,10 @@ class MyAPI(API):
 
 # Usage
 api = MyAPI(client_config=config)
-users = api.users.list()  # GET /users
+user_response = api.users.list()  # GET /users
+users = user_response.values
+# The ``ApiResponse`` wrapper includes additional metadata; access ``values`` or
+# ``data`` for the actual items.
 user = api.users.read(resource_id=1)  # GET /users/1
 user_posts = api.users.posts.list(parent_id=1)  # GET /users/1/posts
 ```


### PR DESCRIPTION
## Summary
- document that `Crud.list` may return an ApiResponse wrapper
- promote accessing `data` or `values` instead of overriding `list`
- mention this usage in ResourceGroup docs

## Testing
- `pre-commit run --files crudclient/crud/operations.py crudclient/crud/README.md docs/resource_groups.md`
- `poetry run pytest -q` *(fails: crudclient exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_6844fa5e71a08332a4b5b370b9a89737