### PR TITLE
Add further reading links

### DIFF
--- a/docs/resource_groups.md
+++ b/docs/resource_groups.md
@@ -303,3 +303,7 @@ The path for a nested resource is constructed by combining the paths of all its 
 2. For a nested `ResourceGroup` or `Crud` with a parent, the path is the parent's path plus its own `_resource_path`.
 
 This hierarchical path construction is handled automatically by the `Crud._get_endpoint()` method.
+## Further Reading
+
+- [Design Proposal](design_proposal_resource_groups.md)
+- [Implementation Plan](implementation_plan_resource_groups.md)


### PR DESCRIPTION
## Summary
- expand resource groups docs with further reading

## Testing
- `pre-commit run --files docs/resource_groups.md -v`
- `poetry run pytest -q` *(fails: KeyboardInterrupt / network-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68458e9cf10483328733a097e9e37488