### PR TITLE
Update changelog and clean up test stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2025-06-11
+
+### Changed
+- Integrated typing from `.pyi` test stubs directly into source files.
+
+### Removed
+- Testing `.pyi` stub files.
+
 ## [0.8.0] - 2025-06-02
 
 ### Changed

--- a/crudclient/testing/crud/assertion_helpers.py
+++ b/crudclient/testing/crud/assertion_helpers.py
@@ -184,9 +184,12 @@ def check_response_handling(
             response_json = request.response.json()  # Use the public json() method
             # Ensure response_json is a dict if expected_data is provided
             if not isinstance(response_json, dict):
+                body_snippet = request.response.text or b""
+                if isinstance(body_snippet, (bytes, bytearray)):
+                    body_snippet = body_snippet.decode()
                 raise AssertionError(
                     f"Request {i} response body is not a JSON object (or is empty), "
-                    f"but expected data was provided. URL: {request.url}. Body: {(request.response.text or '')[:100]}"  # Show snippet
+                    f"but expected data was provided. URL: {request.url}. Body: {body_snippet[:100]}"
                 )
             # Add assertion to help type checker confirm response_json is not None here
             assert response_json is not None

--- a/crudclient/testing/doubles/data_store.py
+++ b/crudclient/testing/doubles/data_store.py
@@ -133,7 +133,6 @@ class DataStore:
         )
 
     def create(self, collection: str, data: Dict[str, Any], skip_validation: bool = False) -> Dict[str, Any]:
-        # Docstring moved to .pyi
         # Note: create_item handles validation internally based on skip_validation
         """Creates a new item in the specified collection."""
         return create_item(
@@ -146,7 +145,6 @@ class DataStore:
     def update(
         self, collection: str, id: Any, data: Dict[str, Any], skip_validation: bool = False, check_version: bool = True
     ) -> Optional[Dict[str, Any]]:
-        # Docstring moved to .pyi
         # Note: update_item handles validation internally based on skip_validation
         """Updates an existing item in a collection identified by its ID."""
         return update_item(

--- a/crudclient/testing/doubles/data_store_definitions.py
+++ b/crudclient/testing/doubles/data_store_definitions.py
@@ -5,8 +5,6 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 
 class ValidationException(Exception):
-    # Docstring moved to .pyi
-
     """Exception raised for data validation errors."""
 
     def __init__(self, message: str, errors: Optional[Dict[str, List[str]]] = None):
@@ -16,8 +14,6 @@ class ValidationException(Exception):
 
 # Moved from data_store.py
 class Relationship:
-    # Docstring moved to .pyi
-
     """Defines a relationship between two collections in the DataStore."""
 
     def __init__(
@@ -53,8 +49,6 @@ class Relationship:
 
 # Moved from data_store.py
 class ValidationRule:
-    # Docstring moved to .pyi
-
     """Defines a validation rule for a specific field in a collection."""
 
     def __init__(
@@ -77,8 +71,6 @@ class ValidationRule:
 
 # Moved from data_store.py
 class UniqueConstraint:
-    # Docstring moved to .pyi
-
     """Defines a unique constraint across one or more fields in a collection."""
 
     def __init__(

--- a/crudclient/testing/doubles/data_store_relationships.py
+++ b/crudclient/testing/doubles/data_store_relationships.py
@@ -101,7 +101,6 @@ def _get_related_one_to_one(
     is_forward_relation: bool,
     related_name: str,
 ) -> List[Dict[str, Any]]:
-    # Docstring moved to .pyi
     if is_forward_relation:
         target_collection_name = related_name
         source_key = relationship.source_key
@@ -128,7 +127,6 @@ def _get_related_one_to_many(
     is_forward_relation: bool,
     related_name: str,
 ) -> List[Dict[str, Any]]:
-    # Docstring moved to .pyi
     if is_forward_relation:  # one(item)-to-many(related_name)
         target_collection_name = related_name
         source_key = relationship.source_key
@@ -155,7 +153,6 @@ def _get_related_many_to_many(
     is_forward_relation: bool,
     related_name: str,
 ) -> List[Dict[str, Any]]:
-    # Docstring moved to .pyi
     if not relationship.junction_collection or relationship.junction_collection not in collections:
         return []
 
@@ -202,7 +199,6 @@ def cascade_delete(
     deleted_field: str = "_deleted",
     updated_at_field: str = "_updated_at",
 ) -> None:
-    # Docstring moved to .pyi
     # Find relationships where this collection is the source
     """Performs cascading deletes based on relationship definitions."""
     for relationship in relationships:

--- a/crudclient/testing/doubles/data_store_sorting.py
+++ b/crudclient/testing/doubles/data_store_sorting.py
@@ -23,7 +23,6 @@ def apply_sorting(data: List[Dict[str, Any]], sort_by: Union[str, List[str]], so
 
     # --- Define multi-level sort key function ---
     def get_sort_key(item: Dict[str, Any]) -> Tuple[Tuple[int, Any], ...]:
-        # Docstring moved to .pyi (inner function, technically not needed in stub)
         key_parts = []
         for field in sort_by_list:
             value: Any = None
@@ -68,7 +67,6 @@ def apply_sorting(data: List[Dict[str, Any]], sort_by: Union[str, List[str]], so
     for i in range(len(sort_by_list) - 1, -1, -1):
         # Create a key function for *only* the current level
         def get_single_level_key(item: Dict[str, Any], level: int = i) -> Tuple[int, Any]:
-            # Docstring moved to .pyi (inner function, technically not needed in stub)
             # This needs to access the outer scope's get_sort_key or replicate its logic for one level
             # Replicating part of get_sort_key logic for clarity and independence:
             field = sort_by_list[level]

--- a/crudclient/testing/doubles/stubs_api.py
+++ b/crudclient/testing/doubles/stubs_api.py
@@ -25,7 +25,6 @@ class StubAPI(API):
         self._data_store: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
     def register_endpoint(self, name: str, endpoint: str, model: Optional[Type[Any]] = None, **kwargs: Any) -> StubCrud:
-        # Docstring moved to .pyi
         # Initialize data store for this endpoint if it doesn't exist
         """Register a new stubbed CRUD endpoint associated with this API instance."""
         if name not in self._data_store:

--- a/crudclient/testing/simple_mock/request_handling.py
+++ b/crudclient/testing/simple_mock/request_handling.py
@@ -280,7 +280,10 @@ class SimpleMockClientRequestHandling(SimpleMockClientCore):
         """
         if response.json_data is not None:
             return json.dumps(response.json_data)
-        return response.text or ""
+        text = response.text or ""
+        if isinstance(text, (bytes, bytearray)):
+            return text.decode()
+        return text
 
     def get(self, url: str, **kwargs: Any) -> str:
         """Perform a GET request.


### PR DESCRIPTION
## Summary
- document removal of `.pyi` stubs in changelog
- decode bytes responses in `SimpleMockClientRequestHandling`
- clean up assertion helper when printing bytes
- drop leftover comments about `.pyi` files in test doubles

## Testing
- `poetry run pre-commit run --files CHANGELOG.md crudclient/testing/doubles/data_store.py crudclient/testing/doubles/data_store_definitions.py crudclient/testing/doubles/data_store_relationships.py crudclient/testing/doubles/data_store_sorting.py crudclient/testing/doubles/stubs_api.py crudclient/testing/simple_mock/request_handling.py crudclient/testing/crud/assertion_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d7ce61a0833282a15b0636e6a320