### PR TITLE
Add context manager to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ if __name__ == '__main__':
 </details>
 
 <details>
+  <summary>Using Client as a context manager</summary>
+
+```python
+from crudclient.client import Client, ClientConfig
+
+config = ClientConfig(hostname="https://api.example.com")
+with Client(config) as client:
+    users = client.get("/users")
+```
+
+</details>
+
+<details>
   <summary>Using ResourceGroups for nested resources</summary>
 
 ```python

--- a/crudclient/client.py
+++ b/crudclient/client.py
@@ -6,7 +6,7 @@ It handles request preparation, authentication, response handling, and error han
 """
 
 import logging
-from typing import Any, Dict, Literal, Optional, Tuple, Union, cast, overload
+from typing import Any, Dict, Literal, Optional, Tuple, Type, Union, cast, overload
 
 import requests
 
@@ -33,6 +33,14 @@ class Client:
 
     This class delegates HTTP operations to the HttpClient class, which handles
     request preparation, authentication, response handling, and error handling.
+    It can be used as a context manager to ensure the session is closed
+    automatically:
+
+    ```python
+    config = ClientConfig(hostname="https://api.example.com")
+    with Client(config) as client:
+        data = client.get("/users")
+    ```
     """
 
     config: ClientConfig
@@ -416,6 +424,19 @@ class Client:
         """
         self.http_client.close()
         log.debug("Client closed.")
+
+    def __enter__(self) -> "Client":
+        """Enter the runtime context and return the client instance."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[Any],
+    ) -> None:
+        """Exit the runtime context and close the client."""
+        self.close()
 
     @property
     def session(self) -> requests.Session:

--- a/tests/unit/client/test_client_base.py
+++ b/tests/unit/client/test_client_base.py
@@ -1,5 +1,7 @@
 import pytest
 
+from crudclient.client import Client
+
 # Import fixtures from conftest.py
 
 
@@ -291,3 +293,13 @@ class TestClient:
         close_mock.assert_called_once()
         assert client.http_client.session_manager.is_closed
         assert session.is_closed
+
+    def test_context_manager(self, default_mock_client_config, requests_mocker):
+        """Ensure Client can be used as a context manager."""
+        url = f"{default_mock_client_config.base_url}/users"
+        requests_mocker.get(url, text="[]")
+
+        with Client(default_mock_client_config) as cm_client:
+            response = cm_client.get("/users")
+
+        assert response == "[]"


### PR DESCRIPTION
## Summary
- implement `__enter__` and `__exit__` in `Client` for context manager support
- document context manager usage in README
- test that the Client works as a context manager

## Testing
- `poetry run pre-commit run --files README.md crudclient/client.py tests/unit/client/test_client_base.py`
- `poetry run pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_684c844704cc8332ba2f039aa0b719b5