### PR TITLE
Use apiconfig logging setup in tests

### DIFF
--- a/tests/debuglogger.py
+++ b/tests/debuglogger.py
@@ -1,28 +1,5 @@
-import logging
+"""Compatibility wrapper for the test suite's logging setup."""
 
+from apiconfig.utils.logging import setup_logging
 
-def setup_logging() -> logging.Logger:
-    # Create the logger for 'crudclient'
-    logger = logging.getLogger("crudclient")
-
-    # Set the logger's level to DEBUG to capture all levels of logs
-    logger.setLevel(logging.DEBUG)
-
-    # Define a standard formatter for the log messages
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-
-    # Create and configure the FileHandler to log to 'error.log'
-    file_handler = logging.FileHandler("/workspace/logs/error.log")
-    file_handler.setLevel(logging.INFO)  # Log only INFO level and above to the file
-    file_handler.setFormatter(formatter)
-
-    # Add the FileHandler to the logger
-    logger.addHandler(file_handler)
-
-    # Optionally, you can also add a StreamHandler to output logs to the console
-    stream_handler = logging.StreamHandler()
-    stream_handler.setLevel(logging.DEBUG)  # Log all levels to the console
-    stream_handler.setFormatter(formatter)
-    logger.addHandler(stream_handler)
-
-    return logger
+__all__ = ["setup_logging"]


### PR DESCRIPTION
## Summary
- use `apiconfig.utils.logging.setup_logging` in test helper

## Testing
- `pre-commit run --files tests/debuglogger.py`
- `pytest -q` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ebca291e8833298b2f8cbc93e593a