### PR TITLE
Add RUN_LIVE_TESTS gating for integration tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -298,8 +298,17 @@ def test_paginated_response(create_paginated_api_response, requests_mocker):
 
 7. **Show extra test summary**:
    ```
-   poetry run pytest -ra  # Show extra test summary info for all except passed tests
-   ```
+poetry run pytest -ra  # Show extra test summary info for all except passed tests
+```
+
+### Live Integration Tests
+
+Integration tests that hit live endpoints are skipped by default. To enable
+them, set the environment variable `RUN_LIVE_TESTS=1` before running pytest:
+
+```bash
+RUN_LIVE_TESTS=1 poetry run pytest tests/integration
+```
 
 ## Coverage
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ Pytest configuration and fixtures for integration tests.
 
 import datetime
 import logging
+import os
 import uuid
 from typing import List, Optional
 
@@ -15,7 +16,21 @@ from .tripletex_resources import TripletexAPI, TripletexTestConfig
 # Load environment variables from .env file
 load_dotenv()
 
+# Environment variable that controls running live tests
+RUN_LIVE_TESTS = os.getenv("RUN_LIVE_TESTS")
+
 logger = logging.getLogger(__name__)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration tests when RUN_LIVE_TESTS is not set."""
+    if RUN_LIVE_TESTS:
+        return
+
+    skip_marker = pytest.mark.skip(reason="RUN_LIVE_TESTS not set; skipping integration tests")
+    for item in items:
+        item.add_marker(skip_marker)
+
 
 # Prefix for test suppliers to identify them for cleanup
 TEST_SUPPLIER_PREFIX = "TEST_CRUDCLIENT_"


### PR DESCRIPTION
## Summary
- allow skipping integration tests unless RUN_LIVE_TESTS is set
- document how to enable live tests in test README

## Testing
- `poetry run pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_684f3d59bd2c8332a58fb96f5a5d9ea5