### PR TITLE
Use apiconfig factories for unit test configs

### DIFF
--- a/tests/unit/auth/test_auth_failures.py
+++ b/tests/unit/auth/test_auth_failures.py
@@ -37,7 +37,7 @@ class TestAuthFailures:
         # Check that the exception contains the error details
         assert "Auth setup failed" in str(excinfo.value)
 
-    def test_auth_param_setup_failure(self, mock_request, create_mock_client_config):
+    def test_auth_param_setup_failure(self, mock_request, create_valid_client_config):
         """
         Test that exceptions during auth parameter setup are propagated.
 
@@ -64,7 +64,7 @@ class TestAuthFailures:
 
         # Configure a client with this auth strategy
         # Configure a client using the factory to inject the custom auth strategy
-        config = create_mock_client_config(auth_strategy=custom_auth)
+        config = create_valid_client_config(auth_strategy=custom_auth)
         client = Client(config)
 
         # Act & Assert

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,8 +8,14 @@ from unittest.mock import MagicMock  # Add MagicMock import
 
 import pytest
 import requests_mock
+from apiconfig.testing.unit.factories import (
+    create_invalid_client_config,
+)
+from apiconfig.testing.unit.factories import (
+    create_valid_client_config as _apiconfig_create_valid_client_config,
+)
 
-from crudclient.auth import AuthStrategy, BasicAuth, BearerAuth, CustomAuth
+from crudclient.auth import BasicAuth, BearerAuth, CustomAuth
 from crudclient.config import ClientConfig
 from crudclient.exceptions import APIError
 from crudclient.testing.response_builder import ResponseBuilder
@@ -49,42 +55,52 @@ def custom_auth_strategy() -> CustomAuth:
 # --- Client Configuration Factory ---
 
 
-@pytest.fixture
-def create_mock_client_config(bearer_auth_strategy: BearerAuth) -> Callable[..., ClientConfig]:
-    """
-    Factory fixture to create a mock ClientConfig instance.
-    Allows customization for different test scenarios.
-    """
+@pytest.fixture(name="create_mock_client_config")
+def create_mock_client_config_fixture(bearer_auth_strategy: BearerAuth) -> Callable[..., ClientConfig]:
+    """Wrapper around :func:`apiconfig.testing.unit.factories.create_valid_client_config`."""
 
-    def _factory(
-        hostname: str = "https://api.example.com",
-        version: str = "v1",
-        api_key: Optional[str] = "default-key",  # Retained for potential direct use if needed
-        auth_strategy: Optional[AuthStrategy] = None,
-        headers: Optional[Dict[str, str]] = None,
-        retries: int = 3,
-        timeout: int = 10,
-        **kwargs: Any,
-    ) -> ClientConfig:
-        config = ClientConfig()
-        config.hostname = hostname
-        config.version = version
-        config.api_key = api_key  # Store it, though auth_strategy is preferred
-        config.auth_strategy = auth_strategy if auth_strategy is not None else bearer_auth_strategy  # Default to Bearer
-        config.headers = headers if headers is not None else {"User-Agent": "crudclient-test"}
-        config.retries = retries
-        config.timeout = timeout
+    def _factory(**kwargs: Any) -> ClientConfig:
+        valid_cfg = _apiconfig_create_valid_client_config(**kwargs)
+        return ClientConfig(
+            hostname=valid_cfg.hostname,
+            version=valid_cfg.version,
+            headers=valid_cfg.headers,
+            timeout=valid_cfg.timeout,
+            retries=valid_cfg.retries,
+            auth_strategy=valid_cfg.auth_strategy or bearer_auth_strategy,
+            log_request_body=valid_cfg.log_request_body,
+            log_response_body=valid_cfg.log_response_body,
+        )
 
-        # Allow overriding any other ClientConfig attributes via kwargs
-        for key, value in kwargs.items():
-            if hasattr(config, key):
-                setattr(config, key, value)
-            else:
-                # Optionally raise an error for unknown kwargs or just ignore
-                # raise AttributeError(f"ClientConfig has no attribute '{key}'")
-                pass  # Ignoring unknown kwargs for flexibility
+    return _factory
 
-        return config
+
+@pytest.fixture(name="create_valid_client_config")
+def create_valid_client_config_fixture(bearer_auth_strategy: BearerAuth) -> Callable[..., ClientConfig]:
+    """Provide a :class:`ClientConfig` compatible with crudclient."""
+
+    def _factory(**kwargs: Any) -> ClientConfig:
+        valid_cfg = _apiconfig_create_valid_client_config(**kwargs)
+        return ClientConfig(
+            hostname=valid_cfg.hostname,
+            version=valid_cfg.version,
+            headers=valid_cfg.headers,
+            timeout=valid_cfg.timeout,
+            retries=valid_cfg.retries,
+            auth_strategy=valid_cfg.auth_strategy or bearer_auth_strategy,
+            log_request_body=valid_cfg.log_request_body,
+            log_response_body=valid_cfg.log_response_body,
+        )
+
+    return _factory
+
+
+@pytest.fixture(name="create_invalid_client_config")
+def create_invalid_client_config_fixture() -> Callable[..., Dict[str, Any]]:
+    """Expose apiconfig factory for invalid configurations."""
+
+    def _factory(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return create_invalid_client_config(*args, **kwargs)
 
     return _factory
 


### PR DESCRIPTION
## Summary
- use `apiconfig.testing.unit.factories` for creating config objects in unit tests
- provide compatibility wrappers in `tests/unit/conftest.py`
- update auth failure test to use new fixture

## Testing
- `pre-commit run --files tests/unit/conftest.py tests/unit/auth/test_auth_failures.py`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6850615e917c8332904210bca9cb787a