### PR TITLE
Add setup_logging export

### DIFF
--- a/crudclient/__init__.py
+++ b/crudclient/__init__.py
@@ -62,6 +62,8 @@ user_posts = api.user_group.posts.list()
 import logging
 from importlib.metadata import version
 
+from apiconfig.utils.logging import setup_logging
+
 from .api import API
 from .auth import (
     ApiKeyAuth,
@@ -140,6 +142,7 @@ __all__ = [  # Updated __all__
     "JSONDict",
     "JSONList",
     "RawResponse",
+    "setup_logging",
 ]
 
 __version__ = version("crudclient")

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -13,6 +13,13 @@ By default, `crudclient` is configured to avoid interfering with the consuming a
 
 To capture log messages from `crudclient`, you must configure the Python `logging` system in your application. This typically involves adding a handler (to specify the destination, e.g., console or file) and setting the desired logging level (e.g., `INFO`, `DEBUG`).
 
+### Quick setup with `setup_logging`
+
+```python
+from crudclient import setup_logging
+setup_logging(level="INFO")
+```
+
 Here are common configuration methods:
 
 **1. Basic Configuration (`logging.basicConfig`)**


### PR DESCRIPTION
## Summary
- expose `setup_logging` from the package
- document how to use `setup_logging`

## Testing
- `poetry run pre-commit run --files crudclient/__init__.py docs/logging.md`

------
https://chatgpt.com/codex/tasks/task_e_685ae4a15b3c8332ad558a6a003b2305