### PR TITLE
Replace config stubs with factory fixtures

### DIFF
--- a/tests/unit/auth/conftest.py
+++ b/tests/unit/auth/conftest.py
@@ -2,7 +2,7 @@
 Fixtures specific to authentication tests.
 """
 
-from typing import Optional, cast
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,15 +22,13 @@ DEFAULT_VERSION = "v1"
 
 
 def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
-    return cast(
-        ClientConfig,
-        create_valid_client_config(
-            hostname=DEFAULT_HOSTNAME,
-            version=DEFAULT_VERSION,
-            headers=headers or {},
-            auth_strategy=auth_strategy,
-        ),
+    base_config = create_valid_client_config(
+        hostname=DEFAULT_HOSTNAME,
+        version=DEFAULT_VERSION,
+        headers=headers or {},
+        auth_strategy=auth_strategy,
     )
+    return ClientConfig(**base_config.__dict__)
 
 
 @pytest.fixture

--- a/tests/unit/auth/conftest.py
+++ b/tests/unit/auth/conftest.py
@@ -2,10 +2,12 @@
 Fixtures specific to authentication tests.
 """
 
+from typing import Optional, cast
 from unittest.mock import MagicMock
 
 import pytest
 import requests_mock
+from apiconfig.testing.unit import create_valid_client_config
 
 from crudclient.client import Client
 from crudclient.config import ClientConfig
@@ -15,110 +17,94 @@ from crudclient.testing.auth import (
     create_bearer_auth_mock,
 )
 
-
-class MockBasicAuthConfig(ClientConfig):
-    """Mock config with Basic Authentication."""
-
-    hostname = "https://api.example.com"
-    version = "v1"
-    headers = {}
-
-    def __init__(self):
-        super().__init__()
-        auth_mock = create_basic_auth_mock(username="user", password="pass")
-        self.auth_strategy = auth_mock.get_auth_strategy()
+DEFAULT_HOSTNAME = "https://api.example.com"
+DEFAULT_VERSION = "v1"
 
 
-class MockBearerAuthConfig(ClientConfig):
-    """Mock config with Bearer Authentication."""
-
-    hostname = "https://api.example.com"
-    version = "v1"
-    headers = {}
-
-    def __init__(self):
-        super().__init__()
-        auth_mock = create_bearer_auth_mock(token="valid_token")
-        self.auth_strategy = auth_mock.get_auth_strategy()
-
-
-class MockRefreshableTokenConfig(ClientConfig):
-    """Mock config with a refreshable token."""
-
-    hostname = "https://api.example.com"
-    version = "v1"
-    headers = {}
-
-    def __init__(self):
-        super().__init__()
-        self.token = "valid_token"
-        self.refresh_token = "refresh_token"
-
-        # Create a bearer auth mock with refresh capability
-        auth_mock = create_bearer_auth_mock(token=self.token)
-        auth_mock.with_refresh_token(self.refresh_token)
-
-        # Store the auth mock for later access
-        self.auth_mock = auth_mock
-        self.auth_strategy = auth_mock.get_auth_strategy()
-        self.should_retry_on_403 = lambda: False  # type: ignore[method-assign]
-        self.handle_403_retry = MagicMock()  # type: ignore[method-assign]
-
-
-class MockApiKeyHeaderConfig(ClientConfig):
-    """Mock config with API Key Header Authentication."""
-
-    hostname = "https://api.example.com"
-    version = "v1"
-    headers = {}
-
-    def __init__(self):
-        super().__init__()
-        auth_mock = create_api_key_auth_mock(api_key="valid_api_key", header_name="X-API-Key")
-        self.auth_strategy = auth_mock.get_auth_strategy()
-
-
-class MockApiKeyParamConfig(ClientConfig):
-    """Mock config with API Key Param Authentication."""
-
-    hostname = "https://api.example.com"
-    version = "v1"
-    headers = {}
-
-    def __init__(self):
-        super().__init__()
-        auth_mock = create_api_key_auth_mock(api_key="valid_api_key", header_name=None, param_name="api_key")
-        self.auth_strategy = auth_mock.get_auth_strategy()
+def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
+    return cast(
+        ClientConfig,
+        create_valid_client_config(
+            hostname=DEFAULT_HOSTNAME,
+            version=DEFAULT_VERSION,
+            headers=headers or {},
+            auth_strategy=auth_strategy,
+        ),
+    )
 
 
 @pytest.fixture
-def basic_auth_client():
+def basic_auth_config() -> ClientConfig:
+    """Return a ClientConfig with Basic Authentication."""
+    auth_mock = create_basic_auth_mock(username="user", password="pass")
+    return _build_config(auth_mock.get_auth_strategy())
+
+
+@pytest.fixture
+def bearer_auth_config() -> ClientConfig:
+    """Return a ClientConfig with Bearer Authentication."""
+    auth_mock = create_bearer_auth_mock(token="valid_token")
+    return _build_config(auth_mock.get_auth_strategy())
+
+
+@pytest.fixture
+def refreshable_token_config() -> ClientConfig:
+    """Return a ClientConfig with a refreshable token."""
+    token = "valid_token"
+    refresh_token = "refresh_token"
+    auth_mock = create_bearer_auth_mock(token=token)
+    auth_mock.with_refresh_token(refresh_token)
+    config = _build_config(auth_mock.get_auth_strategy())
+    config.token = token  # type: ignore[attr-defined]
+    config.refresh_token = refresh_token  # type: ignore[attr-defined]
+    config.auth_mock = auth_mock  # type: ignore[attr-defined]
+    config.should_retry_on_403 = lambda: False  # type: ignore[method-assign]
+    config.handle_403_retry = MagicMock()  # type: ignore[method-assign]
+    return config
+
+
+@pytest.fixture
+def apikey_header_config() -> ClientConfig:
+    """Return a ClientConfig with API Key Header Authentication."""
+    auth_mock = create_api_key_auth_mock(api_key="valid_api_key", header_name="X-API-Key")
+    return _build_config(auth_mock.get_auth_strategy())
+
+
+@pytest.fixture
+def apikey_param_config() -> ClientConfig:
+    """Return a ClientConfig with API Key Param Authentication."""
+    auth_mock = create_api_key_auth_mock(api_key="valid_api_key", header_name=None, param_name="api_key")
+    return _build_config(auth_mock.get_auth_strategy())
+
+
+@pytest.fixture
+def basic_auth_client(basic_auth_config: ClientConfig) -> Client:
     """Create a client with Basic Authentication for testing."""
-    return Client(MockBasicAuthConfig())
+    return Client(basic_auth_config)
 
 
 @pytest.fixture
-def bearer_auth_client():
+def bearer_auth_client(bearer_auth_config: ClientConfig) -> Client:
     """Create a client with Bearer Authentication for testing."""
-    return Client(MockBearerAuthConfig())
+    return Client(bearer_auth_config)
 
 
 @pytest.fixture
-def refreshable_token_client():
+def refreshable_token_client(refreshable_token_config: ClientConfig) -> Client:
     """Create a client with a refreshable token for testing."""
-    return Client(MockRefreshableTokenConfig())
+    return Client(refreshable_token_config)
 
 
 @pytest.fixture
-def apikey_header_client():
+def apikey_header_client(apikey_header_config: ClientConfig) -> Client:
     """Create a client with API Key Header Authentication for testing."""
-    return Client(MockApiKeyHeaderConfig())
+    return Client(apikey_header_config)
 
 
 @pytest.fixture
-def apikey_param_client():
+def apikey_param_client(apikey_param_config: ClientConfig) -> Client:
     """Create a client with API Key Param Authentication for testing."""
-    return Client(MockApiKeyParamConfig())
+    return Client(apikey_param_config)
 
 
 @pytest.fixture

--- a/tests/unit/auth/test_auth_failures.py
+++ b/tests/unit/auth/test_auth_failures.py
@@ -10,7 +10,6 @@ from crudclient.client import Client
 from crudclient.config import ClientConfig
 
 # Import fixtures from conftest.py - Fixtures are typically auto-discovered by pytest
-from .conftest import bearer_auth_config
 
 
 class TestAuthFailures:

--- a/tests/unit/auth/test_auth_failures.py
+++ b/tests/unit/auth/test_auth_failures.py
@@ -7,15 +7,16 @@ from apiconfig.exceptions.auth import AuthStrategyError
 
 from crudclient.auth import CustomAuth
 from crudclient.client import Client
+from crudclient.config import ClientConfig
 
 # Import fixtures from conftest.py - Fixtures are typically auto-discovered by pytest
-from .conftest import MockBearerAuthConfig  # Needed for test_auth_setup_failure
+from .conftest import bearer_auth_config
 
 
 class TestAuthFailures:
     """Tests for general authentication failure handling."""
 
-    def test_auth_setup_failure(self, mock_request, mocker):
+    def test_auth_setup_failure(self, mock_request, mocker, bearer_auth_config: ClientConfig):
         """Test handling of authentication setup failures."""
         # Arrange
         # Create a bearer auth mock with a failing callback
@@ -25,7 +26,7 @@ class TestAuthFailures:
         mock_prepare_headers.side_effect = Exception("Auth setup failed")
 
         # Create a client with the failing auth
-        config = MockBearerAuthConfig()
+        config = bearer_auth_config
 
         # Act & Assert
         # Creating the client or making a request should raise the exception

--- a/tests/unit/auth/test_custom_auth_failures.py
+++ b/tests/unit/auth/test_custom_auth_failures.py
@@ -7,19 +7,18 @@ from apiconfig.exceptions.auth import AuthStrategyError
 
 from crudclient.auth import CustomAuth
 from crudclient.client import Client
+from crudclient.config import ClientConfig
 from crudclient.exceptions import AuthenticationError
 
-from .conftest import MockBasicAuthConfig
 
-
-def test_custom_auth_failure(mock_request):
+def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig):
     """Test handling of custom authentication failures during setup."""
 
     def header_callback():
         """Simulate a failure during header generation."""
         raise ValueError("Failed to generate custom header")
 
-    config = MockBasicAuthConfig()
+    config = basic_auth_config
     config.auth_strategy = CustomAuth(header_callback=header_callback)
 
     with pytest.raises(AuthStrategyError) as excinfo:
@@ -30,13 +29,13 @@ def test_custom_auth_failure(mock_request):
     assert "Failed to generate custom header" in str(excinfo.value.__cause__)
 
 
-def test_custom_auth_param_callback_failure(mock_request):
+def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: ClientConfig):
     """Test that exceptions from param_callback are propagated."""
 
     def failing_param_callback() -> dict:
         raise ValueError("Failed during param generation")
 
-    config = MockBasicAuthConfig()
+    config = basic_auth_config
     config.auth_strategy = CustomAuth(header_callback=lambda: {}, param_callback=failing_param_callback)
     client = Client(config)
 
@@ -44,13 +43,13 @@ def test_custom_auth_param_callback_failure(mock_request):
         client.get("/some/path")
 
 
-def test_custom_auth_api_failure(mock_request):
+def test_custom_auth_api_failure(mock_request, basic_auth_config: ClientConfig):
     """Test handling of API returning 401/403 with CustomAuth."""
 
     def get_headers():
         return {"X-Custom": "valid"}
 
-    config = MockBasicAuthConfig()
+    config = basic_auth_config
     config.auth_strategy = CustomAuth(header_callback=get_headers)
     client = Client(config)
 

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -2,54 +2,61 @@
 Fixtures specific to client tests.
 """
 
+from typing import Optional, cast
+
 import pytest
 import requests_mock
+from apiconfig.testing.unit import create_valid_client_config
 
 from crudclient.auth import BasicAuth, BearerAuth, CustomAuth
 from crudclient.client import Client
 from crudclient.config import ClientConfig
 
-
-class MockBearerAuthConfig(ClientConfig):
-    """Mock config with Bearer Authentication."""
-
-    headers = {"X-Custom-Header": "custom-value"}
-    api_key = "supersecret"
-
-    def __init__(self):
-        super().__init__(hostname="https://api.example.com", version="v1")
-        self.auth_strategy = BearerAuth(access_token="supersecret")
-        self.retries = 0
+DEFAULT_HOSTNAME = "https://api.example.com"
+DEFAULT_VERSION = "v1"
 
 
-class MockBasicAuthConfig(ClientConfig):
-    """Mock config with Basic Authentication."""
-
-    def __init__(self):
-        super().__init__(hostname="https://api.example.com", version="v1")
-        self.auth_strategy = BasicAuth(username="user", password="pass")
-
-
-class MockCustomAuthConfig(ClientConfig):
-    """Mock config with Custom Authentication."""
-
-    def __init__(self):
-        super().__init__(hostname="https://api.example.com", version="v1")
-        self.called = False
-
-        def apply_auth_headers(session):
-            session.headers.update({"X-Auth": "yes"})
-            self.called = True
-            return {}
-
-        self.auth_strategy = CustomAuth(header_callback=lambda: {"X-Auth": "yes"})
+def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
+    return cast(
+        ClientConfig,
+        create_valid_client_config(
+            hostname=DEFAULT_HOSTNAME,
+            version=DEFAULT_VERSION,
+            headers=headers or {},
+            auth_strategy=auth_strategy,
+        ),
+    )
 
 
 @pytest.fixture
-def client():
+def bearer_auth_config() -> ClientConfig:
+    """Return a ClientConfig with Bearer Authentication."""
+    auth_strategy = BearerAuth(access_token="supersecret")
+    config = _build_config(auth_strategy, headers={"X-Custom-Header": "custom-value"})
+    config.api_key = "supersecret"
+    config.retries = 0
+    return config
+
+
+@pytest.fixture
+def basic_auth_config() -> ClientConfig:
+    """Return a ClientConfig with Basic Authentication."""
+    auth_strategy = BasicAuth(username="user", password="pass")
+    return _build_config(auth_strategy)
+
+
+@pytest.fixture
+def custom_auth_config() -> ClientConfig:
+    """Return a ClientConfig with Custom Authentication."""
+    config = _build_config(CustomAuth(header_callback=lambda: {"X-Auth": "yes"}))
+    config.called = False  # type: ignore[attr-defined]
+    return config
+
+
+@pytest.fixture
+def client(bearer_auth_config: ClientConfig) -> Client:
     """Create a client with Bearer Authentication for testing."""
-    config = MockBearerAuthConfig()
-    return Client(config)
+    return Client(bearer_auth_config)
 
 
 @pytest.fixture

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -2,7 +2,7 @@
 Fixtures specific to client tests.
 """
 
-from typing import Optional, cast
+from typing import Optional
 
 import pytest
 import requests_mock
@@ -17,15 +17,13 @@ DEFAULT_VERSION = "v1"
 
 
 def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
-    return cast(
-        ClientConfig,
-        create_valid_client_config(
-            hostname=DEFAULT_HOSTNAME,
-            version=DEFAULT_VERSION,
-            headers=headers or {},
-            auth_strategy=auth_strategy,
-        ),
+    base_config = create_valid_client_config(
+        hostname=DEFAULT_HOSTNAME,
+        version=DEFAULT_VERSION,
+        headers=headers or {},
+        auth_strategy=auth_strategy,
     )
+    return ClientConfig(**base_config.__dict__)
 
 
 @pytest.fixture

--- a/tests/unit/client/test_client_auth.py
+++ b/tests/unit/client/test_client_auth.py
@@ -2,8 +2,8 @@ from crudclient.auth import BearerAuth
 from crudclient.client import Client
 from crudclient.config import ClientConfig
 
-# Import fixtures from conftest.py
-from .conftest import MockBasicAuthConfig, MockCustomAuthConfig
+# Fixtures from conftest.py
+from .conftest import basic_auth_config, custom_auth_config
 
 
 class TestClientAuth:
@@ -24,9 +24,9 @@ class TestClientAuth:
         assert client.config.version == "v1"
         assert client.session.headers["X-Test"] == "1"
 
-    def test_client_basic_auth_sets_session_headers(self):
+    def test_client_basic_auth_sets_session_headers(self, basic_auth_config: ClientConfig):
         # Arrange
-        config = MockBasicAuthConfig()
+        config = basic_auth_config
 
         # Act
         client = Client(config)
@@ -35,9 +35,9 @@ class TestClientAuth:
         # Just check that the Authorization header exists
         assert "Authorization" in client.session.headers
 
-    def test_client_custom_auth_applies_headers(self):
+    def test_client_custom_auth_applies_headers(self, custom_auth_config: ClientConfig):
         # Arrange
-        config = MockCustomAuthConfig()
+        config = custom_auth_config
 
         # Act
         client = Client(config)

--- a/tests/unit/client/test_client_auth.py
+++ b/tests/unit/client/test_client_auth.py
@@ -3,7 +3,6 @@ from crudclient.client import Client
 from crudclient.config import ClientConfig
 
 # Fixtures from conftest.py
-from .conftest import basic_auth_config, custom_auth_config
 
 
 class TestClientAuth:


### PR DESCRIPTION
## Summary
- use `create_valid_client_config` in auth and client fixtures
- update tests to consume new fixtures
- factor out shared `_build_config` helper

## Testing
- `poetry run pre-commit run --files tests/unit/auth/conftest.py tests/unit/client/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_685ae4bd2f208332a342b07663186d65