### PR TITLE
Refactor auth test helpers

### DIFF
--- a/crudclient/testing/auth/README.md
+++ b/crudclient/testing/auth/README.md
@@ -53,10 +53,11 @@ The `factory.py` module provides convenient functions (`create_basic_auth_mock`,
 
 The `verification.py` module provides the `AuthVerificationHelpers` class, which aggregates static methods from several specialized utility classes:
 
-*   **`AuthHeaderVerification`**: Methods to verify the format and structure of `Authorization` headers (Basic, Bearer, API Key).
+*   **`AuthHeaderVerification`** (from `apiconfig.testing`): Methods to verify the format and structure of `Authorization` headers (Basic, Bearer, API Key).
 *   **`AuthTokenVerification`**: Methods to verify token properties, primarily for JWTs (expiration, scopes, client ID, user) and refresh behavior.
 *   **`AuthErrorVerification`**: Methods to verify authentication error responses (status code, error codes) and standard rate limit headers.
 *   **`AuthExtractionUtils`**: Methods to parse credentials/tokens from Basic/Bearer headers and extract payloads from JWTs.
+*   **`AuthTestHelpers`**: Convenience wrappers for asserting auth headers were applied using the `apiconfig` utilities.
 
 These helpers can be used in tests to assert that the client is sending the correct authentication information or that the mock is behaving as expected.
 

--- a/crudclient/testing/auth/auth_header_verification.py
+++ b/crudclient/testing/auth/auth_header_verification.py
@@ -1,5 +1,0 @@
-"""Compatibility wrapper for authentication header verification utilities."""
-
-from apiconfig.testing.auth_verification import AuthHeaderVerification
-
-__all__ = ["AuthHeaderVerification"]

--- a/crudclient/testing/auth/verification.py
+++ b/crudclient/testing/auth/verification.py
@@ -18,13 +18,16 @@ extraction methods may raise `ValueError` for invalid input formats.
 from typing import Any, Dict, List, Optional, Tuple
 
 from apiconfig.exceptions.auth import AuthenticationError
+from apiconfig.testing.auth_verification import (
+    AuthHeaderVerification,
+    AuthTestHelpers,
+)
 
 from ..exceptions import VerificationError
 from .auth_error_verification import AuthErrorVerification
 
 # Re-export the classes from their respective modules
 from .auth_extraction_utils import AuthExtractionUtils
-from .auth_header_verification import AuthHeaderVerification
 from .auth_token_verification import AuthTokenVerification
 
 
@@ -61,9 +64,9 @@ class AuthVerificationHelpers:
             >>> # Raises VerificationError: AuthVerificationHelpers.verify_basic_auth_header("Bearer token")
         """
         try:
-            AuthHeaderVerification.verify_basic_auth_header(header_value)
+            AuthTestHelpers.assert_auth_applied({"Authorization": header_value}, "basic")
             return True
-        except AuthenticationError:
+        except AssertionError:
             return False
 
     @staticmethod
@@ -89,9 +92,9 @@ class AuthVerificationHelpers:
             >>> # Raises VerificationError: AuthVerificationHelpers.verify_bearer_auth_header("Basic dXNlcjpwYXNz")
         """
         try:
-            AuthHeaderVerification.verify_bearer_auth_header(header_value)
+            AuthTestHelpers.assert_auth_applied({"Authorization": header_value}, "bearer")
             return True
-        except AuthenticationError:
+        except AssertionError:
             return False
 
     @staticmethod
@@ -154,8 +157,8 @@ class AuthVerificationHelpers:
             >>> # Raises VerificationError: AuthVerificationHelpers.verify_auth_header_format({}, "Bearer")
         """
         try:
-            AuthHeaderVerification.verify_auth_header_format(headers, auth_type, header_name)
-        except AuthenticationError as exc:
+            AuthTestHelpers.assert_auth_applied(headers, auth_type, header_name=header_name)
+        except AssertionError as exc:
             raise VerificationError(str(exc)) from exc
 
     # Token verification methods
@@ -463,4 +466,10 @@ class AuthVerificationHelpers:
 
 
 # For backward compatibility
-__all__ = ["AuthVerificationHelpers", "AuthExtractionUtils", "AuthHeaderVerification", "AuthTokenVerification", "AuthErrorVerification"]
+__all__ = [
+    "AuthVerificationHelpers",
+    "AuthExtractionUtils",
+    "AuthTokenVerification",
+    "AuthErrorVerification",
+    "AuthTestHelpers",
+]

--- a/docs/testing_design_patterns.md
+++ b/docs/testing_design_patterns.md
@@ -14,7 +14,7 @@ The testing utilities now contain inline type hints in the implementation files,
 
 *   **What:** Encapsulates the logic for verifying interactions with test doubles (mocks, spies, fakes). It provides dedicated functions or methods for making assertions about method calls, arguments, call counts, or state changes.
 *   **Why:** Decouples assertion logic from the test double itself and the main test flow, leading to cleaner tests and reusable verification logic. This is particularly useful for complex checks, such as call sequences, specific header contents, or authentication details.
-*   **Where:** General verification logic resides in `crudclient.testing.verification.Verifier` (often raising `VerificationError`). More specialized verification helpers exist for specific concerns, such as those in `crudclient.testing.auth` modules (e.g., `auth_header_verification`, `auth_token_verification`), which typically raise standard `AssertionError` exceptions for integration with testing frameworks like `pytest`.
+*   **Where:** General verification logic resides in `crudclient.testing.verification.Verifier` (often raising `VerificationError`). More specialized verification helpers exist for specific concerns, such as those in `crudclient.testing.auth` modules (e.g., `AuthVerificationHelpers`, `auth_token_verification`), which typically raise standard `AssertionError` exceptions for integration with testing frameworks like `pytest`.
 
 ## 3. Test Spy Pattern
 


### PR DESCRIPTION
## Summary
- delegate auth verification helpers to `apiconfig` implementations
- remove unused `auth_header_verification` wrapper
- reference `AuthTestHelpers` and update docs

## Testing
- `poetry run pre-commit run --files crudclient/testing/auth/verification.py tests/unit/auth/*`

------
https://chatgpt.com/codex/tasks/task_e_685ae4afc2fc8332937af7db85626dda