### PR TITLE
Remove unused Request/ResponseVerifier placeholders

### DIFF
--- a/crudclient/testing/__init__.py
+++ b/crudclient/testing/__init__.py
@@ -45,18 +45,6 @@ from .simple_mock import SimpleMockClient  # Import SimpleMockClient
 from .spy import MethodCall, SpyBase
 from .verification import Verifier
 
-# These classes are referenced in tests but don't seem to exist in the codebase
-# Defining placeholder classes to avoid import errors
-
-
-class RequestVerifier:
-    """Placeholder for RequestVerifier class referenced in tests."""
-
-
-class ResponseVerifier:
-    """Placeholder for ResponseVerifier class referenced in tests."""
-
-
 __all__ = [
     # Main classes
     "MockClient",
@@ -71,8 +59,6 @@ __all__ = [
     "SimpleMockClient",
     "APIPatternBuilder",
     "ResponseBuilder",
-    "RequestVerifier",
-    "ResponseVerifier",
     # Auth mocks
     "ApiKeyAuthMock",
     "AuthMockBase",


### PR DESCRIPTION
## Summary
- drop unused RequestVerifier and ResponseVerifier
- update `__all__`

## Testing
- `pre-commit run --files crudclient/testing/__init__.py`
- `pre-commit run --files tests/unit/conftest.py`


------
https://chatgpt.com/codex/tasks/task_e_685b54ed76ec8332afa14e800937336d