### PR TITLE
Fix cast for status code exceptions

### DIFF
--- a/crudclient/http/errors.py
+++ b/crudclient/http/errors.py
@@ -110,7 +110,10 @@ class ErrorHandler:
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
-            exception_class = self.status_code_to_exception.get(status_code, APIError)
+            exception_class = cast(
+                Type[CrudClientError],
+                self.status_code_to_exception.get(status_code, APIError),
+            )
 
             error_message = f"HTTP error {status_code}: {error_data}"
 


### PR DESCRIPTION
## Summary
- ensure status_code_to_exception result is cast to CrudClientError before checking with `issubclass`

## Testing
- `pre-commit run --files crudclient/http/errors.py`
- `poetry run pyright crudclient/http/errors.py`


------
https://chatgpt.com/codex/tasks/task_e_6864aaa060088332889608e734e27f0c