### PR TITLE
Fix MockResponse error attribute

### DIFF
--- a/crudclient/testing/response_builder/response.py
+++ b/crudclient/testing/response_builder/response.py
@@ -8,6 +8,8 @@ class MockResponse:
     Used in testing scenarios to provide controlled response data without making actual network calls.
     """
 
+    error: Optional[Exception] = None
+
     def __init__(
         self,
         status_code: int,
@@ -28,6 +30,7 @@ class MockResponse:
         self.json_data = json_data
         self.text = text
         self.headers = headers if headers is not None else {}
+        self.error = None
 
     def json(self) -> Optional[Dict]:
         """Returns the JSON data provided during initialization."""


### PR DESCRIPTION
## Summary
- add missing `error` field to `MockResponse` for easier error handling
- run pre-commit hooks and pyright

## Testing
- `poetry run pyright`
- `poetry run pytest -q` *(fails: ConnectionError to api.fiken.no and jsonplaceholder.typicode.com)*

------
https://chatgpt.com/codex/tasks/task_e_6864aac60a1483329727e19394d08827