### PR TITLE
Fix pydantic ConfigDict usage

### DIFF
--- a/crudclient/models.py
+++ b/crudclient/models.py
@@ -131,7 +131,7 @@ class IdRef(BaseModel):
 
     id: int
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
 
 class IdUrl(BaseModel):

--- a/tests/integration/tripletex_resources/models/api_response_model.py
+++ b/tests/integration/tripletex_resources/models/api_response_model.py
@@ -37,7 +37,7 @@ class TripletexResponse(ApiResponse[T], Generic[T]):
         return self.values
 
     # Override model_config to handle both Tripletex and ApiResponse field names
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
     def __init__(self, **data):
         # If count is not provided, use the length of values

--- a/tests/integration/tripletex_resources/models/ledger.py
+++ b/tests/integration/tripletex_resources/models/ledger.py
@@ -44,7 +44,7 @@ class Ledger(BaseModel):
     is_applicable_for_customer_invoice: Optional[bool] = Field(None, alias="isApplicableForCustomerInvoice")
     vat_type: Optional[IdUrl] = Field(None, alias="vatType")
 
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -59,7 +59,7 @@ class LedgerResponse(TripletexResponse[Ledger]):
     """
 
     # The data field is already defined in the parent class with proper aliases
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
 
 class Voucher(BaseModel):
@@ -92,7 +92,7 @@ class Voucher(BaseModel):
     created: Optional[Change] = None
     updated: Optional[Change] = None
 
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
 
 class VoucherResponse(TripletexResponse[Voucher]):
@@ -101,7 +101,7 @@ class VoucherResponse(TripletexResponse[Voucher]):
     """
 
     # The data field is already defined in the parent class with proper aliases
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
 
 class HistoricalVoucher(BaseModel):
@@ -119,7 +119,7 @@ class HistoricalVoucher(BaseModel):
     year: Optional[int] = None
     postings: Optional[List[dict]] = None
 
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
 
 
 class HistoricalVoucherResponse(TripletexResponse[HistoricalVoucher]):
@@ -128,4 +128,4 @@ class HistoricalVoucherResponse(TripletexResponse[HistoricalVoucher]):
     """
 
     # The data field is already defined in the parent class with proper aliases
-    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")

--- a/tests/integration/tripletex_resources/models/supplier.py
+++ b/tests/integration/tripletex_resources/models/supplier.py
@@ -48,7 +48,7 @@ class Supplier(BaseModel):
     locale: str
     website: str
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
 
 # Input models for create/update operations


### PR DESCRIPTION
## Summary
- update `IdRef` and integration models to use `validate_by_name`/`validate_by_alias` instead of deprecated `populate_by_name`

## Testing
- `pre-commit run --files crudclient/models.py tests/integration/tripletex_resources/models/api_response_model.py tests/integration/tripletex_resources/models/ledger.py tests/integration/tripletex_resources/models/supplier.py`
- `pytest -q` *(fails: crudclient couldn't reach external services)*

------
https://chatgpt.com/codex/tasks/task_e_6864aaccb05c8332a58a576a0686592b