### PR TITLE
Ensure ModelDumpable bound for TripletexResponse

### DIFF
--- a/tests/integration/tripletex_resources/models/api_response_model.py
+++ b/tests/integration/tripletex_resources/models/api_response_model.py
@@ -3,8 +3,9 @@ from typing import Generic, List, Optional, TypeVar
 from pydantic import BaseModel, ConfigDict, Field
 
 from crudclient.models import ApiResponse
+from crudclient.response_strategies import ModelDumpable
 
-T = TypeVar("T")
+T = TypeVar("T", bound=ModelDumpable)
 
 
 class TripletexResponse(ApiResponse[T], Generic[T]):


### PR DESCRIPTION
## Summary
- bind `TripletexResponse` generic parameter to `ModelDumpable`

## Testing
- `poetry run pre-commit run --files tests/integration/tripletex_resources/models/api_response_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6864aace9abc8332b26957466c32d35e