### PR TITLE
Fix session cleanup in Client.close

### DIFF
--- a/crudclient/client.py
+++ b/crudclient/client.py
@@ -423,6 +423,12 @@ class Client:
         to ensure proper cleanup of resources.
         """
         self.http_client.close()
+        # Ensure the session exposes the `is_closed` attribute even if it
+        # wasn't accessed prior to calling ``close``. Accessing the
+        # ``session`` property attaches a dynamic ``is_closed`` property
+        # to the underlying ``requests.Session`` instance that proxies the
+        # value from ``SessionManager``.
+        _ = self.session
         log.debug("Client closed.")
 
     def __enter__(self) -> "Client":


### PR DESCRIPTION
## Summary
- ensure the client's session exposes `is_closed` when `close()` is called

## Testing
- `poetry run pre-commit run --files crudclient/client.py tests/unit/client/test_client_base.py`
- `poetry run pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6864aad0952c8332a2fe38a0aceb98f7