### PR TITLE
Fix list result handling in simple mock test

### DIFF
--- a/tests/unit/crud/test_crud_with_simple_mock.py
+++ b/tests/unit/crud/test_crud_with_simple_mock.py
@@ -59,6 +59,8 @@ def test_list_operation_success(
 
     # Call the list operation
     result = base_test_crud_httpserver.list()
+    if hasattr(result, "data"):
+        result = result.data
 
     # Verify the result
     assert len(result) == 2


### PR DESCRIPTION
## Summary
- handle `.data` attribute in `test_list_operation_success`

## Testing
- `pre-commit run --files tests/unit/crud/test_crud_with_simple_mock.py`

------
https://chatgpt.com/codex/tasks/task_e_686594be1e9083329de90d74ad4570f6