### PR TITLE
Fix default headers test

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,6 +40,8 @@ class TestClientConfig:
         assert auth == {"Authorization": f"Bearer {config.api_key}"}
 
     def test_get_default_headers(self, config: MockClientConfig) -> None:
+        if config.headers is None:
+            config.headers = {}  # type: ignore[unreachable]
         config.headers["Accept"] = "application/json"
         assert isinstance(config.headers, dict)
         assert config.headers == {"Accept": "application/json"}


### PR DESCRIPTION
## Summary
- ensure config headers is a dict before assigning in `test_get_default_headers`

## Testing
- `poetry run pre-commit run --files tests/unit/test_config.py`
- `poetry run pre-commit run -a`


------
https://chatgpt.com/codex/tasks/task_e_686594b1cb588332b86bf8495b03f8f9