### PR TITLE
Fix loop in build nested structure

### DIFF
--- a/crudclient/testing/helpers/partial_response.py
+++ b/crudclient/testing/helpers/partial_response.py
@@ -194,7 +194,7 @@ class PartialResponseHelper:
             final_value: The value to set at the end of the path
         """
         current = result
-        for i, part in enumerate(parts[:-1]):
+        for part in parts[:-1]:
             if part not in current:
                 current[part] = {}
             current = current[part]


### PR DESCRIPTION
## Summary
- simplify loop in `_build_nested_structure`

## Testing
- `poetry run pre-commit run --files crudclient/testing/helpers/partial_response.py`
- `poetry run pytest -q` *(fails: ProxyError from blocked connections)*

------
https://chatgpt.com/codex/tasks/task_e_6865948c99488332be46d37cc392b4b3