### PR TITLE
Remove _op_nin handler

### DIFF
--- a/crudclient/testing/doubles/data_store_helpers.py
+++ b/crudclient/testing/doubles/data_store_helpers.py
@@ -109,11 +109,6 @@ def _op_in(value: Any, op_value: Any) -> bool:
     return bool(value in op_value)
 
 
-def _op_nin(value: Any, op_value: Any) -> bool:
-    """Check if value is not in op_value."""
-    return bool(value not in op_value)
-
-
 def _op_exists(value: Any, op_value: bool) -> bool:
     """Check if value exists (is not None) when op_value is True,"""
     if op_value:


### PR DESCRIPTION
## Summary
- remove unused `_op_nin` helper
- keep `$nin` implementation via `_op_in` lambda

## Testing
- `poetry run autoflake --remove-all-unused-imports --check --recursive .`
- `poetry run isort --check --profile black .`
- `poetry run black --check .`
- `poetry run flake8`
- `poetry run mypy`
- `poetry run pytest --cov=crudclient` *(fails: connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6865947b2fdc83329b1c677859ece037