### PR TITLE
Fix type hints in update mock

### DIFF
--- a/crudclient/testing/crud/update.py
+++ b/crudclient/testing/crud/update.py
@@ -55,11 +55,11 @@ class UpdateMock(BaseCrudMock):
         pattern = self._find_matching_pattern(method, url, **kwargs)
 
         if pattern:
-            response_obj = pattern["response"]
+            raw_response = pattern["response"]
+            if callable(raw_response):
+                raw_response = raw_response(**kwargs)
 
-            # Handle callable responses
-            if callable(response_obj):
-                response_obj = response_obj(**kwargs)
+            response_obj: MockResponse | Dict[str, Any] | List[Dict[str, Any]] | str = raw_response
 
             # Handle errors
             if "error" in pattern and pattern["error"]:


### PR DESCRIPTION
## Summary
- ensure `response_obj` is typed before calling `_ensure_mock_response`

## Testing
- `pre-commit run --files crudclient/testing/crud/update.py`
- `poetry run pytest -q` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68659479d00883328dd57b720286a4ac