### PR TITLE
Improve fixture return types

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 # Removed incorrect imports for internal types: LogCaptureHandler, Config
 from typing import (  # Ensure List and Type are imported
     Any,
+    Callable,
     List,
     Optional,
 )
@@ -30,7 +31,7 @@ def base_url() -> str:
 
 
 @pytest.fixture
-def mock_response_factory() -> Any:
+def mock_response_factory() -> Callable[..., Mock]:
     """
     Factory fixture to create mock response objects with custom attributes.
 
@@ -117,7 +118,7 @@ def temp_file(tmp_path: Any) -> Any:
 
 
 @pytest.fixture
-def manage_env_vars(monkeypatch: Any) -> Any:
+def manage_env_vars(monkeypatch: Any) -> tuple[Callable[[str, Any], None], Callable[[str, bool], None]]:
     """
     Fixture providing functions to safely set/unset environment variables
     during a test, automatically restoring the original state afterwards.


### PR DESCRIPTION
## Summary
- use explicit Callable and tuple return types for pytest fixtures

## Testing
- `pre-commit run --files tests/conftest.py`
- `mypy tests/conftest.py`
- `pytest -q` *(fails: crudclient.exceptions.ClientResponseError ...)*

------
https://chatgpt.com/codex/tasks/task_e_686598540d88833280e510699fd112be