### PR TITLE
Add return type hints for integration fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ Pytest configuration and fixtures for integration tests.
 import datetime
 import logging
 import uuid
-from typing import List, Optional
+from typing import Callable, Iterator, List, Optional
 
 import pytest
 from dotenv import load_dotenv
@@ -22,7 +22,7 @@ TEST_SUPPLIER_PREFIX = "TEST_CRUDCLIENT_"
 
 
 @pytest.fixture
-def api():
+def api() -> TripletexAPI:
     """
     Create a Tripletex API client for testing.
     """
@@ -31,7 +31,7 @@ def api():
 
 
 @pytest.fixture
-def supplier_tracker(api):
+def supplier_tracker(api) -> Iterator[list[int]]:
     """
     Track suppliers created during tests for cleanup.
     Returns a list that tests can append supplier IDs to.
@@ -50,7 +50,7 @@ def supplier_tracker(api):
 
 
 @pytest.fixture
-def unique_supplier_name():
+def unique_supplier_name() -> str:
     """
     Generate a unique supplier name with test prefix and timestamp.
     """
@@ -60,7 +60,7 @@ def unique_supplier_name():
 
 
 @pytest.fixture
-def find_unused_supplier_number(api):
+def find_unused_supplier_number(api) -> Callable[[int, int], Optional[str]]:
     """
     Factory fixture to find an unused supplier number.
     """
@@ -91,7 +91,7 @@ def find_unused_supplier_number(api):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def cleanup_orphaned_test_suppliers(request):
+def cleanup_orphaned_test_suppliers(request) -> None:
     """
     Session-level fixture that runs after all tests to clean up any orphaned test suppliers.
     This catches suppliers that weren't cleaned up due to test failures.


### PR DESCRIPTION
## Summary
- add concrete typing for integration fixtures

## Testing
- `poetry run pre-commit run --files tests/integration/conftest.py`
- `poetry run pytest -k '' -q` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_686598534c7c833298ef12313e264d43