### PR TITLE
Add type hints for rate limit integration tests

### DIFF
--- a/tests/integration/test_http_client_rate_limiting.py
+++ b/tests/integration/test_http_client_rate_limiting.py
@@ -18,7 +18,7 @@ from crudclient.ratelimit import get_rate_limiter
 class TestHttpClientRateLimitingSimple:
     """Test that HttpClient properly integrates with the rate limiter."""
 
-    def test_rate_limiter_called_before_request(self):
+    def test_rate_limiter_called_before_request(self) -> None:
         """Test that the rate limiter check_and_wait is called before making requests."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create config with rate limiting enabled
@@ -61,7 +61,7 @@ class TestHttpClientRateLimitingSimple:
                         mock_check_and_wait.assert_called_once()
                         mock_update.assert_called_once_with(mock_response.headers)
 
-    def test_rate_limiting_blocks_requests(self):
+    def test_rate_limiting_blocks_requests(self) -> None:
         """Test that rate limiting actually blocks requests when limit is reached."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Set worker count to avoid pytest-xdist interference


### PR DESCRIPTION
## Summary
- add `-> None` return types to rate limit integration tests

## Testing
- `poetry run pre-commit run --files tests/integration/test_http_client_rate_limiting.py`
- `poetry run pytest tests/integration/test_http_client_rate_limiting.py::TestHttpClientRateLimitingSimple::test_rate_limiter_called_before_request -q` *(fails: Missing required tokens for authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68659850884c83328958398dba35cda1