### PR TITLE
Fix integration test annotations

### DIFF
--- a/tests/integration/test_rate_limit_integration.py
+++ b/tests/integration/test_rate_limit_integration.py
@@ -87,7 +87,7 @@ def api_worker(
 class TestRateLimitIntegration:
     """Integration tests for rate limiting."""
 
-    def test_multi_process_rate_limiting(self):
+    def test_multi_process_rate_limiting(self) -> None:
         """Test rate limiting across multiple processes."""
         with tempfile.TemporaryDirectory() as temp_dir:
             num_workers = 4
@@ -166,7 +166,7 @@ class TestRateLimitIntegration:
                 # We expect some blocking to occur
                 assert total_blocked > 0, f"No blocking occurred: {total_blocked} == 0"
 
-    def test_rate_limiter_with_http_client(self):
+    def test_rate_limiter_with_http_client(self) -> None:
         """Test rate limiter integration with HttpClient."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create config with rate limiting


### PR DESCRIPTION
## Summary
- fix missing return annotations for TestRateLimitIntegration

## Testing
- `poetry run mypy tests/integration/test_rate_limit_integration.py`
- `poetry run pre-commit run --files tests/integration/test_rate_limit_integration.py`
- `poetry run pytest` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865984fd34083329c35d08c8ac661d8