### PR TITLE
Annotate factory tests

### DIFF
--- a/tests/unit/testing/test_factory.py
+++ b/tests/unit/testing/test_factory.py
@@ -19,7 +19,7 @@ from tests.unit.helpers import VerifiableMock, translate_mock_calls_for_verifier
 class TestMockClientFactory:
     """Tests for the MockClientFactory class."""
 
-    def test_create_default(self):
+    def test_create_default(self) -> None:
         """Test create method with default parameters."""
         # Act
         mock_client = MockClientFactory.create()
@@ -30,7 +30,7 @@ class TestMockClientFactory:
         assert mock_client.base_url == "https://api.example.com"
         assert mock_client.enable_spy is False
 
-    def test_create_with_custom_parameters(self):
+    def test_create_with_custom_parameters(self) -> None:
         """Test create method with custom parameters."""
         # Arrange
         base_url = "https://test.example.com"
@@ -48,65 +48,61 @@ class TestMockClientFactory:
         assert mock_client.enable_spy is enable_spy
         # We can't directly check extra_param as it's passed to the constructor but not stored as an attribute
 
-    def test_from_client_config_default(self):
+    def test_from_client_config_default(self, valid_config: ClientConfig) -> None:
         """Test from_client_config method with default config."""
         # Arrange
-        config = ClientConfig()
-        config.hostname = "https://test.example.com"
+        valid_config.hostname = "https://test.example.com"
 
         # Act
-        mock_client = MockClientFactory.from_client_config(config)
+        mock_client = MockClientFactory.from_client_config(valid_config)
 
         # Assert
         assert isinstance(mock_client, MockClient)
         # Assert that the base_url from config.hostname is stored
-        assert mock_client.base_url == config.hostname
+        assert mock_client.base_url == valid_config.hostname
         assert mock_client.enable_spy is False
 
-    def test_from_client_config_with_auth_strategy(self):
+    def test_from_client_config_with_auth_strategy(self, valid_config: ClientConfig) -> None:
         """Test from_client_config method with auth strategy."""
         # Arrange
-        config = ClientConfig()
-        config.hostname = "https://test.example.com"
+        valid_config.hostname = "https://test.example.com"
         auth_strategy = BearerAuth(access_token="test-token")
-        config.auth_strategy = auth_strategy
+        valid_config.auth_strategy = auth_strategy
 
         # Act
-        mock_client = MockClientFactory.from_client_config(config)
+        mock_client = MockClientFactory.from_client_config(valid_config)
 
         # Assert
         assert isinstance(mock_client, MockClient)
         # Assert that the base_url from config.hostname is stored
-        assert mock_client.base_url == config.hostname
+        assert mock_client.base_url == valid_config.hostname
         assert mock_client.get_auth_strategy() is auth_strategy
 
-    def test_from_client_config_with_custom_parameters(self):
+    def test_from_client_config_with_custom_parameters(self, valid_config: ClientConfig) -> None:
         """Test from_client_config method with custom parameters."""
         # Arrange
-        config = ClientConfig()
-        config.hostname = "https://test.example.com"
+        valid_config.hostname = "https://test.example.com"
         enable_spy = True
         extra_param = "extra_value"
 
         # Act
-        mock_client = MockClientFactory.from_client_config(config=config, enable_spy=enable_spy, extra_param=extra_param)
+        mock_client = MockClientFactory.from_client_config(config=valid_config, enable_spy=enable_spy, extra_param=extra_param)
 
         # Assert
         assert isinstance(mock_client, MockClient)
         # Assert that the base_url from config.hostname is stored
-        assert mock_client.base_url == config.hostname
+        assert mock_client.base_url == valid_config.hostname
         assert mock_client.enable_spy is enable_spy
 
-    def test_from_real_client(self):
+    def test_from_real_client(self, valid_config: ClientConfig) -> None:
         """Test from_real_client method."""
         # Arrange
-        config = ClientConfig()
-        config.hostname = "https://test.example.com"
+        valid_config.hostname = "https://test.example.com"
         auth_strategy = BearerAuth(access_token="test-token")
-        config.auth_strategy = auth_strategy
+        valid_config.auth_strategy = auth_strategy
 
-        client = MagicMock(spec=Client)
-        client.config = config
+        client: MagicMock = MagicMock(spec=Client)
+        client.config = valid_config
 
         # Act
         mock_client = MockClientFactory.from_real_client(client)
@@ -114,17 +110,16 @@ class TestMockClientFactory:
         # Assert
         assert isinstance(mock_client, MockClient)
         # Assert that the base_url from the real client's config.hostname is stored
-        assert mock_client.base_url == config.hostname
+        assert mock_client.base_url == valid_config.hostname
         assert mock_client.get_auth_strategy() is auth_strategy
 
-    def test_from_real_client_with_custom_parameters(self):
+    def test_from_real_client_with_custom_parameters(self, valid_config: ClientConfig) -> None:
         """Test from_real_client method with custom parameters."""
         # Arrange
-        config = ClientConfig()
-        config.hostname = "https://test.example.com"
+        valid_config.hostname = "https://test.example.com"
 
-        client = MagicMock(spec=Client)
-        client.config = config
+        client: MagicMock = MagicMock(spec=Client)
+        client.config = valid_config
 
         enable_spy = True
         extra_param = "extra_value"
@@ -135,13 +130,13 @@ class TestMockClientFactory:
         # Assert
         assert isinstance(mock_client, MockClient)
         # Assert that the base_url from the real client's config.hostname is stored
-        assert mock_client.base_url == config.hostname
+        assert mock_client.base_url == valid_config.hostname
         assert mock_client.enable_spy is enable_spy
 
-    def test_configure_success_response(self):
+    def test_configure_success_response(self) -> None:
         """Test configure_success_response method."""
         # Arrange
-        mock_client = VerifiableMock(spec=MockClient)
+        mock_client: MagicMock = VerifiableMock(spec=MockClient)
 
         # Act
         MockClientFactory.configure_success_response(
@@ -162,10 +157,10 @@ class TestMockClientFactory:
             headers={"Content-Type": "application/json"},
         )
 
-    def test_configure_error_response_with_error(self):
+    def test_configure_error_response_with_error(self) -> None:
         """Test configure_error_response method with an error."""
         # Arrange
-        mock_client = VerifiableMock(spec=MockClient)
+        mock_client: MagicMock = VerifiableMock(spec=MockClient)
         error = ValueError("Test error")
 
         # Act
@@ -177,10 +172,10 @@ class TestMockClientFactory:
         # Assert
         Verifier.verify_called_once_with(mock_client, "configure_response", method="GET", path="/test", error=error)
 
-    def test_configure_error_response_without_error(self):
+    def test_configure_error_response_without_error(self) -> None:
         """Test configure_error_response method without an error."""
         # Arrange
-        mock_client = VerifiableMock(spec=MockClient)
+        mock_client: MagicMock = VerifiableMock(spec=MockClient)
 
         # Act
         MockClientFactory.configure_error_response(


### PR DESCRIPTION
## Summary
- add `-> None` return annotations to factory unit tests
- type-hint fixture params with `ClientConfig`
- type-hint local mocks with `MagicMock`

## Testing
- `pre-commit run --files tests/unit/testing/test_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_6865ab4978c88332a32088284886f08f