### PR TITLE
Add type hints to RetryHandler tests

### DIFF
--- a/tests/unit/http/test_retry_handler.py
+++ b/tests/unit/http/test_retry_handler.py
@@ -85,9 +85,7 @@ class TestRetryCondition:
     def test_custom_retry_condition(self) -> None:
         """Test that custom retry conditions work correctly."""
 
-        def custom_condition(
-            response: Optional[requests.Response], exception: Optional[BaseException]
-        ) -> bool:
+        def custom_condition(response: Optional[requests.Response], exception: Optional[BaseException]) -> bool:
             if response and response.headers.get("Retry-After"):
                 return True
             return False
@@ -109,9 +107,7 @@ class TestRetryCondition:
 class TestRetryHandler:
     """Tests for the retry handler class."""
 
-    def test_should_retry_status_code(
-        self, retry_handler: RetryHandler, mocker: MockerFixture
-    ) -> None:
+    def test_should_retry_status_code(self, retry_handler: RetryHandler, mocker: MockerFixture) -> None:
         """Test that the retry handler correctly identifies status codes to retry on."""
         response_500 = mocker.Mock(spec=requests.Response)
         response_500.status_code = 500
@@ -143,9 +139,7 @@ class TestRetryHandler:
         assert retry_handler.get_delay(2) == 0.01
         assert retry_handler.get_delay(3) == 0.01
 
-    def test_execute_with_retry_success_first_try(
-        self, retry_handler: RetryHandler, mocker: MockerFixture
-    ) -> None:
+    def test_execute_with_retry_success_first_try(self, retry_handler: RetryHandler, mocker: MockerFixture) -> None:
         """Test that the retry handler returns the response if the first try succeeds."""
         mock_sleep = mocker.patch("time.sleep")
         mock_response = mocker.Mock(spec=requests.Response)
@@ -161,9 +155,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_not_called(mock_sleep, "")
 
-    def test_execute_with_retry_success_after_retry(
-        self, mocker: MockerFixture
-    ) -> None:
+    def test_execute_with_retry_success_after_retry(self, mocker: MockerFixture) -> None:
         """Test that the retry handler retries and returns the response if a retry succeeds."""
         # Instantiate specific handler for this test
         # Use jitter=False for predictable delay, default base_delay is 0.5
@@ -188,9 +180,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_called_once_with(mock_sleep, "", 1.0)  # Expect default base delay (1.0)
 
-    def test_execute_with_retry_all_failures(
-        self, retry_handler: RetryHandler, mocker: MockerFixture
-    ) -> None:
+    def test_execute_with_retry_all_failures(self, retry_handler: RetryHandler, mocker: MockerFixture) -> None:
         """Test that the retry handler raises an exception if all retries fail."""
         mock_sleep = mocker.patch("time.sleep")
 
@@ -246,9 +236,7 @@ class TestRetryHandler:
                 break
         assert error_log_found, "Expected ERROR log for exhausted retries due to exception not found"
 
-    def test_execute_with_retry_non_retryable_exception(
-        self, retry_handler: RetryHandler, mocker: MockerFixture
-    ) -> None:
+    def test_execute_with_retry_non_retryable_exception(self, retry_handler: RetryHandler, mocker: MockerFixture) -> None:
         """Test that the retry handler doesn't retry on non-retryable exceptions."""
         mock_sleep = mocker.patch("time.sleep")
 
@@ -352,9 +340,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(callback)
         Verifier.verify_any_call(callback, "", 2, 0.01, mock_error_response, None)
 
-    def test_execute_with_retry_raises_network_error(
-        self, retry_handler: RetryHandler, mocker: MockerFixture
-    ) -> None:
+    def test_execute_with_retry_raises_network_error(self, retry_handler: RetryHandler, mocker: MockerFixture) -> None:
         """Test that NetworkError is raised for requests.exceptions.RequestException."""
         mock_sleep = mocker.patch("time.sleep")
         original_exception = requests_exceptions.ConnectionError("Failed to connect")

--- a/tests/unit/http/test_retry_handler.py
+++ b/tests/unit/http/test_retry_handler.py
@@ -1,8 +1,10 @@
 import logging  # <-- Add import
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
 import requests
+from pytest_mock import MockerFixture
 from requests import exceptions as requests_exceptions  # Import requests exceptions
 
 from crudclient.exceptions import CrudClientError, NetworkError
@@ -83,7 +85,9 @@ class TestRetryCondition:
     def test_custom_retry_condition(self) -> None:
         """Test that custom retry conditions work correctly."""
 
-        def custom_condition(response, exception):
+        def custom_condition(
+            response: Optional[requests.Response], exception: Optional[BaseException]
+        ) -> bool:
             if response and response.headers.get("Retry-After"):
                 return True
             return False
@@ -105,7 +109,9 @@ class TestRetryCondition:
 class TestRetryHandler:
     """Tests for the retry handler class."""
 
-    def test_should_retry_status_code(self, retry_handler, mocker):
+    def test_should_retry_status_code(
+        self, retry_handler: RetryHandler, mocker: MockerFixture
+    ) -> None:
         """Test that the retry handler correctly identifies status codes to retry on."""
         response_500 = mocker.Mock(spec=requests.Response)
         response_500.status_code = 500
@@ -117,7 +123,7 @@ class TestRetryHandler:
         assert retry_handler.should_retry(0, response_404) is False
         assert retry_handler.should_retry(3, response_500) is False
 
-    def test_should_retry_exception(self, retry_handler):
+    def test_should_retry_exception(self, retry_handler: RetryHandler) -> None:
         """Test that the retry handler correctly identifies exceptions to retry on."""
         timeout_exception = requests.Timeout()
         connection_error = requests.ConnectionError()
@@ -128,7 +134,7 @@ class TestRetryHandler:
         assert retry_handler.should_retry(0, exception=value_error) is False
         assert retry_handler.should_retry(3, exception=timeout_exception) is False
 
-    def test_get_delay(self):
+    def test_get_delay(self) -> None:
         """Test that the retry handler correctly calculates the delay."""
         # Instantiate specific handler for this test
         retry_handler = RetryHandler(retry_strategy=FixedRetryStrategy(delay=0.01))
@@ -137,7 +143,9 @@ class TestRetryHandler:
         assert retry_handler.get_delay(2) == 0.01
         assert retry_handler.get_delay(3) == 0.01
 
-    def test_execute_with_retry_success_first_try(self, retry_handler, mocker):
+    def test_execute_with_retry_success_first_try(
+        self, retry_handler: RetryHandler, mocker: MockerFixture
+    ) -> None:
         """Test that the retry handler returns the response if the first try succeeds."""
         mock_sleep = mocker.patch("time.sleep")
         mock_response = mocker.Mock(spec=requests.Response)
@@ -153,7 +161,9 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_not_called(mock_sleep, "")
 
-    def test_execute_with_retry_success_after_retry(self, mocker):
+    def test_execute_with_retry_success_after_retry(
+        self, mocker: MockerFixture
+    ) -> None:
         """Test that the retry handler retries and returns the response if a retry succeeds."""
         # Instantiate specific handler for this test
         # Use jitter=False for predictable delay, default base_delay is 0.5
@@ -178,7 +188,9 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_called_once_with(mock_sleep, "", 1.0)  # Expect default base delay (1.0)
 
-    def test_execute_with_retry_all_failures(self, retry_handler, mocker):
+    def test_execute_with_retry_all_failures(
+        self, retry_handler: RetryHandler, mocker: MockerFixture
+    ) -> None:
         """Test that the retry handler raises an exception if all retries fail."""
         mock_sleep = mocker.patch("time.sleep")
 
@@ -197,7 +209,12 @@ class TestRetryHandler:
         Verifier.verify_call_count(mock_sleep, "", 3)
 
     # Modified test
-    def test_execute_with_retry_exception_logs_error(self, retry_handler, mocker, caplog):
+    def test_execute_with_retry_exception_logs_error(
+        self,
+        retry_handler: RetryHandler,
+        mocker: MockerFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """Test that the retry handler handles exceptions correctly and logs an error."""
         mock_sleep = mocker.patch("time.sleep")
         exception_instance = requests.Timeout("Connection timed out")
@@ -229,7 +246,9 @@ class TestRetryHandler:
                 break
         assert error_log_found, "Expected ERROR log for exhausted retries due to exception not found"
 
-    def test_execute_with_retry_non_retryable_exception(self, retry_handler, mocker):
+    def test_execute_with_retry_non_retryable_exception(
+        self, retry_handler: RetryHandler, mocker: MockerFixture
+    ) -> None:
         """Test that the retry handler doesn't retry on non-retryable exceptions."""
         mock_sleep = mocker.patch("time.sleep")
 
@@ -244,7 +263,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_not_called(mock_sleep, "")
 
-    def test_retry_on_403_configured(self, mocker):
+    def test_retry_on_403_configured(self, mocker: MockerFixture) -> None:
         """Test execute_with_retry retries on 403 if configured, but doesn't call setup_auth."""
         mock_sleep = mocker.patch("time.sleep")
         setup_auth_func = mocker.Mock()
@@ -276,7 +295,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_called_once_with(mock_sleep, "", 0.01)
 
-    def test_no_retry_on_404_when_403_configured(self, mocker):
+    def test_no_retry_on_404_when_403_configured(self, mocker: MockerFixture) -> None:
         """Test execute_with_retry doesn't retry on 404 if only 403 is configured."""
         mock_sleep = mocker.patch("time.sleep")
         setup_auth_func = mocker.Mock()
@@ -304,7 +323,7 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(mock_sleep)
         Verifier.verify_not_called(mock_sleep, "")
 
-    def test_on_retry_callback(self, mocker):
+    def test_on_retry_callback(self, mocker: MockerFixture) -> None:
         """Test that the on_retry_callback is called correctly."""
         mocker.patch("time.sleep")
         callback = mocker.Mock()
@@ -333,7 +352,9 @@ class TestRetryHandler:
         translate_mock_calls_for_verifier(callback)
         Verifier.verify_any_call(callback, "", 2, 0.01, mock_error_response, None)
 
-    def test_execute_with_retry_raises_network_error(self, retry_handler, mocker):
+    def test_execute_with_retry_raises_network_error(
+        self, retry_handler: RetryHandler, mocker: MockerFixture
+    ) -> None:
         """Test that NetworkError is raised for requests.exceptions.RequestException."""
         mock_sleep = mocker.patch("time.sleep")
         original_exception = requests_exceptions.ConnectionError("Failed to connect")


### PR DESCRIPTION
## Summary
- annotate RetryHandler test fixtures and functions with return type `-> None`
- specify parameter types such as `RetryHandler` and `MockerFixture`
- type-hint custom_condition in retry handler tests

## Testing
- `pre-commit run --files tests/unit/http/test_retry_handler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ab4086c8833299ed224dba5cbe5a