### PR TITLE
Fix fixture return typing in tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -123,7 +123,7 @@ def requests_mocker():
 
 
 @pytest.fixture
-def create_user_data():
+def create_user_data() -> Callable[..., Dict[str, Any]]:
     """Factory fixture to create user test data."""
     """Factory fixture to create user test data with unique IDs."""
     _id_counter = 1
@@ -140,7 +140,7 @@ def create_user_data():
 
 
 @pytest.fixture
-def create_api_response():
+def create_api_response() -> Callable[..., Dict[str, Any]]:
     """Factory fixture to create API response data."""
     """
     Factory fixture to create versatile API response data for requests_mock.


### PR DESCRIPTION
## Summary
- add callable return annotations for create_user_data and create_api_response

## Testing
- `pre-commit run --files tests/unit/conftest.py`
- `poetry run pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6865bade906483328a0782a6712b78af