### PR TITLE
Add explicit type hints in OAuth scope validator tests

### DIFF
--- a/tests/unit/testing/auth/test_oauth_scope_validator.py
+++ b/tests/unit/testing/auth/test_oauth_scope_validator.py
@@ -1,9 +1,11 @@
+from typing import List, Optional
+
 import pytest
 
 from crudclient.testing.auth.oauth_scope_validator import OAuthScopeValidator
 
 
-def test_scope_validator_init():
+def test_scope_validator_init() -> None:
     """Test initial state of the scope validator."""
     validator = OAuthScopeValidator()
     # Check default available scopes (might change, so check a few known ones)
@@ -12,14 +14,14 @@ def test_scope_validator_init():
     assert validator.required_scopes == set()
 
 
-def test_set_available_scopes():
+def test_set_available_scopes() -> None:
     """Test setting available scopes, overwriting defaults."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["scope1", "scope2"])
     assert validator.available_scopes == {"scope1", "scope2"}
 
 
-def test_add_available_scope():
+def test_add_available_scope() -> None:
     """Test adding an available scope."""
     validator = OAuthScopeValidator()
     initial_scopes = validator.available_scopes.copy()
@@ -27,14 +29,14 @@ def test_add_available_scope():
     assert validator.available_scopes == initial_scopes.union({"new_scope"})
 
 
-def test_set_required_scopes():
+def test_set_required_scopes() -> None:
     """Test setting required scopes."""
     validator = OAuthScopeValidator()
     validator.set_required_scopes(["req1", "req2"])
     assert validator.required_scopes == {"req1", "req2"}
 
 
-def test_add_required_scope():
+def test_add_required_scope() -> None:
     """Test adding a required scope."""
     validator = OAuthScopeValidator()
     validator.add_required_scope("req1")
@@ -78,7 +80,12 @@ def test_add_required_scope():
         ([], ["read"], "", False),  # Required scope not available
     ],
 )
-def test_validate_scopes(available, required, provided, expected):
+def test_validate_scopes(
+    available: Optional[List[str]],
+    required: Optional[List[str]],
+    provided: Optional[str],
+    expected: bool,
+) -> None:
     validator = OAuthScopeValidator()
     if available is not None:
         validator.set_available_scopes(available)
@@ -88,7 +95,7 @@ def test_validate_scopes(available, required, provided, expected):
     assert validator.validate_scopes(provided) is expected
 
 
-def test_get_default_scopes_no_required():
+def test_get_default_scopes_no_required() -> None:
     """Test default scopes when none are required."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "profile", "email"])
@@ -96,7 +103,7 @@ def test_get_default_scopes_no_required():
     assert validator.get_default_scopes() == "read"
 
 
-def test_get_default_scopes_with_required():
+def test_get_default_scopes_with_required() -> None:
     """Test default scopes includes required scopes."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "admin", "profile"])
@@ -105,7 +112,7 @@ def test_get_default_scopes_with_required():
     assert validator.get_default_scopes() == "admin profile read"
 
 
-def test_get_default_scopes_required_not_available():
+def test_get_default_scopes_required_not_available() -> None:
     """Test default scopes when required scope isn't available (edge case)."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "write"])


### PR DESCRIPTION
## Summary
- add type hints for test functions in `test_oauth_scope_validator`
- ensure tests return `None`

## Testing
- `poetry run pre-commit run --files tests/unit/testing/auth/test_oauth_scope_validator.py`
- `poetry run pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_6865bad9a0ec8332a199897e1a5734a9