### PR TITLE
Annotate client error tests

### DIFF
--- a/tests/unit/http/errors/test_client_errors.py
+++ b/tests/unit/http/errors/test_client_errors.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
 from crudclient.exceptions import (
     APIError,
@@ -17,12 +18,13 @@ from crudclient.exceptions import (
     NotFoundError,
     UnprocessableEntityError,
 )
+from crudclient.http.client import HttpClient
 
 
 class TestHttpClientClientErrors:
     """Tests for handling client errors in the HTTP client."""
 
-    def test_400_error(self, http_client, mock_request):
+    def test_400_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 400 Bad Request.
 
@@ -41,7 +43,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid parameters"
 
-    def test_401_error(self, http_client, mock_request):
+    def test_401_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 401 Unauthorized.
 
@@ -60,7 +62,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Authentication required"
 
-    def test_403_error(self, http_client, mock_request):
+    def test_403_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 403 Forbidden.
 
@@ -79,7 +81,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Insufficient permissions"
 
-    def test_404_error(self, http_client, mock_request):
+    def test_404_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 404 Not Found.
 
@@ -98,7 +100,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Resource not found"
 
-    def test_422_error(self, http_client, mock_request):
+    def test_422_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 422 Unprocessable Entity.
 
@@ -117,7 +119,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Validation failed"
 
-    def test_429_error(self, http_client, mock_request):
+    def test_429_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 429 Too Many Requests.
 


### PR DESCRIPTION
## Summary
- add typing imports and annotate test methods in client error tests

## Testing
- `pre-commit run --files tests/unit/http/errors/test_client_errors.py`
- `pytest tests/unit/http/errors/test_client_errors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bfbecb4c8332ba8b832d358fd52d