### PR TITLE
Fix custom auth callbacks typing

### DIFF
--- a/tests/unit/client/auth_examples/test_custom_auth.py
+++ b/tests/unit/client/auth_examples/test_custom_auth.py
@@ -16,14 +16,14 @@ from .common import create_mock_client
 class TestCustomAuthExamples:
     """Examples of using Custom Authentication mocks."""
 
-    def test_custom_auth_success_scenario(self):
+    def test_custom_auth_success_scenario(self) -> None:
         """Example of testing a successful Custom Auth scenario."""
 
         # Define custom auth callbacks
-        def header_callback():
+        def header_callback() -> dict[str, str]:
             return {"X-Custom-Auth": "custom_value", "X-Timestamp": "12345678"}
 
-        def param_callback():
+        def param_callback() -> dict[str, str]:
             return {"tenant": "test_tenant"}
 
         # Create a mock client with Custom Auth
@@ -50,11 +50,11 @@ class TestCustomAuthExamples:
         # Assuming 'path' contains the full URL or path with params
         assert request.kwargs["params"].get("tenant") == "test_tenant"
 
-    def test_custom_auth_failure_scenario(self):
+    def test_custom_auth_failure_scenario(self) -> None:
         """Example of testing a Custom Auth failure scenario."""
 
         # Define a custom auth callback that will fail
-        def failing_header_callback():
+        def failing_header_callback() -> dict[str, str]:
             raise ValueError("Failed to generate auth headers")
 
         # Create a mock client with failing Custom Auth


### PR DESCRIPTION
## Summary
- annotate test methods with `-> None`
- define explicit return types for auth callbacks in tests

## Testing
- `pre-commit run --files tests/unit/client/auth_examples/test_custom_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6865c02b8eb48332b8d6bb996cb9f919