### PR TITLE
Add explicit None return types to logging completion tests

### DIFF
--- a/tests/unit/http/test_http_logging_completion.py
+++ b/tests/unit/http/test_http_logging_completion.py
@@ -53,7 +53,7 @@ def test_log_request_completion_success(
     mock_logger: MagicMock,
     mock_response: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify successful request completion logging."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -75,7 +75,7 @@ def test_log_request_completion_failure_response(
     mock_logger: MagicMock,
     mock_response: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify failed request completion logging (with error response)."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -106,7 +106,7 @@ def test_log_request_completion_failure_exception(
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,  # Need request info for the log
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify failed request completion logging (with exception)."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -128,7 +128,7 @@ def test_log_request_completion_no_outcome(
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify request completion logging when outcome is None."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]


### PR DESCRIPTION
## Summary
- add `-> None` to four http logging completion tests

## Testing
- `pre-commit run --files tests/unit/http/test_http_logging_completion.py`

------
https://chatgpt.com/codex/tasks/task_e_6865c02aba508332b6213295d8b992d8