### PR TITLE
Add typing to validation logging tests

### DIFF
--- a/tests/unit/crud/test_validation_logging.py
+++ b/tests/unit/crud/test_validation_logging.py
@@ -4,10 +4,12 @@ Unit tests for logging during CRUD request and response data validation.
 
 import json
 import logging
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from pydantic import ValidationError as PydanticValidationError
+from pytest_mock import MockerFixture
 
 from crudclient.exceptions import DataValidationError
 
@@ -36,11 +38,11 @@ class TestCrudRequestValidationLogging:
     def test_request_validation_error_logs_error(
         self,
         base_test_crud: BaseTestCrud,
-        mocker: MagicMock,
-        caplog,
+        mocker: MockerFixture,
+        caplog: pytest.LogCaptureFixture,
         operation_name: str,
-        operation_args: dict,
-    ):
+        operation_args: dict[str, Any],
+    ) -> None:
         """
         GIVEN a CRUD operation (create, update, partial_update)
         WHEN input data fails Pydantic validation before the API call
@@ -115,11 +117,11 @@ class TestCrudResponseValidationLogging:
         self,
         base_test_crud: BaseTestCrud,
         mock_client: MagicMock,
-        caplog,
+        caplog: pytest.LogCaptureFixture,
         operation_name: str,
-        operation_args: dict,
+        operation_args: dict[str, Any],
         client_method_name: str,
-    ):
+    ) -> None:
         """
         GIVEN a CRUD operation returning a single item
         WHEN the API response data fails Pydantic validation
@@ -172,8 +174,8 @@ class TestCrudResponseValidationLogging:
         self,
         base_test_crud: BaseTestCrud,
         mock_client: MagicMock,
-        caplog,
-    ):
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """
         GIVEN a 'list' operation
         WHEN the API response list contains data that fails Pydantic validation


### PR DESCRIPTION
## Summary
- add `Any`/`MockerFixture` imports for test typing
- annotate logging tests with types and return `None`

## Testing
- `poetry run pre-commit run --files tests/unit/crud/test_validation_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_6865c027001883328d2903cb10b977f2