### PR TITLE
Fix type hints in HTTP retry tests

### DIFF
--- a/tests/unit/http/errors/test_retry_behavior.py
+++ b/tests/unit/http/errors/test_retry_behavior.py
@@ -5,13 +5,15 @@ This module contains tests for how the HTTP client handles retries for various
 error conditions, including network errors, timeouts, and SSL errors.
 """
 
-from typing import cast
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 import requests
 import requests_mock
+from requests_mock.response import _Context
 
+from crudclient.config import ClientConfig
 from crudclient.exceptions import CrudClientError
 from crudclient.http import RetryCondition, RetryHandler
 from crudclient.http.client import HttpClient
@@ -21,14 +23,14 @@ class TestHttpClientNetworkErrorRetries:
     """Tests for retry behavior with network errors in the HTTP client."""
 
     @pytest.fixture
-    def retry_config(self, config):
+    def retry_config(self, config: ClientConfig) -> ClientConfig:
         """Fixture for a configuration with custom retry settings."""
         # Set a short timeout for faster tests
-        config.timeout = 1.0
+        config.timeout = 1
         return config
 
     @pytest.fixture
-    def retry_client(self, retry_config):
+    def retry_client(self, retry_config: ClientConfig) -> HttpClient:
         """Fixture for an HTTP client with custom retry settings."""
         # Create a retry handler with custom settings
         retry_handler = RetryHandler(
@@ -54,7 +56,7 @@ class TestHttpClientNetworkErrorRetries:
         # Track the number of requests
         request_count = [0]
 
-        def side_effect(request, context):
+        def side_effect(request: requests.PreparedRequest, context: _Context) -> dict[str, Any]:
             request_count[0] += 1
             if request_count[0] <= 2:  # Fail the first two attempts
                 raise requests.exceptions.ConnectionError("Connection refused")
@@ -90,7 +92,7 @@ class TestHttpClientNetworkErrorRetries:
         # Track the number of requests
         request_count = [0]
 
-        def side_effect(request, context):
+        def side_effect(request: requests.PreparedRequest, context: _Context) -> dict[str, Any]:
             request_count[0] += 1
             if request_count[0] <= 2:  # Fail the first two attempts
                 raise requests.exceptions.Timeout("Request timed out")
@@ -128,7 +130,7 @@ class TestHttpClientNetworkErrorRetries:
         # Track the number of requests
         request_count = [0]
 
-        def side_effect(request, context):
+        def side_effect(request: requests.PreparedRequest, context: _Context) -> dict[str, Any]:
             request_count[0] += 1
             if request_count[0] <= 2:  # Fail the first two attempts
                 raise requests.exceptions.SSLError("SSL: CERTIFICATE_VERIFY_FAILED")
@@ -185,16 +187,14 @@ class TestHttpClientNetworkErrorRetries:
         # Track the number of requests
         request_count = [0]
 
-        def side_effect(request, context):
+        def side_effect(request: requests.PreparedRequest, context: _Context) -> dict[str, Any]:
             request_count[0] += 1
             if request_count[0] == 1:
                 raise requests.exceptions.ConnectionError("Connection refused")
             elif request_count[0] == 2:
                 raise requests.exceptions.Timeout("Request timed out")
-            elif request_count[0] == 3:
-                # Succeed on the third attempt instead of raising another error
-                context.status_code = 200
-                return {"id": 1, "name": "Test User"}
+            context.status_code = 200
+            return {"id": 1, "name": "Test User"}
 
         mock_request.get(url, json=side_effect)
 


### PR DESCRIPTION
## Summary
- type annotate `retry_config` and `retry_client` fixtures
- type annotate nested `side_effect` functions
- import `_Context` from `requests_mock.response`

## Testing
- `pre-commit run --files tests/unit/http/errors/test_retry_behavior.py`
- `pytest tests/unit/http/errors/test_retry_behavior.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c026a3408332a3022bc02a1edd18