### PR TITLE
Fix registration annotations

### DIFF
--- a/crudclient/__init__.py
+++ b/crudclient/__init__.py
@@ -37,10 +37,10 @@ class UserGroup(ResourceGroup[User]):
         self.posts = PostsCrud(self.client, parent=self)
 
 class MyAPI(API):
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         self.users = UsersCrud(self.client)
 
-    def _register_groups(self):
+    def _register_groups(self) -> None:
         self.user_group = UserGroup(self.client)
 
 # Create a configuration with bearer token authentication

--- a/crudclient/api.py
+++ b/crudclient/api.py
@@ -19,7 +19,7 @@ Example
 class MyAPI(API):
     client_class = MyClient
 
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         self.contacts = Contacts(self.client)
 
 api = MyAPI(client_config=ClientConfig(**{'api_key': 'your_api_key'}))

--- a/tests/integration/fiken_resources/setup.py
+++ b/tests/integration/fiken_resources/setup.py
@@ -72,7 +72,7 @@ class FikenContacts(FikenCrud[Contact]):
 class FikenAPI(API):
     client_class = Client
 
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         assert self.client is not None, "Client is required!"
         self.user = FikenUser(self.client)
         self.companies = FikenCompanies(self.client)

--- a/tests/integration/oneflow_resources/setup.py
+++ b/tests/integration/oneflow_resources/setup.py
@@ -80,7 +80,7 @@ class OneflowDataFields(Crud[DataField]):
 class OneflowAPI(API):
     client_class = Client
 
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         assert self.client is not None, "Client is not initialized"
 
         self.users = UsersCrud(self.client)

--- a/tests/integration/tripletex_resources/api.py
+++ b/tests/integration/tripletex_resources/api.py
@@ -16,7 +16,7 @@ class TripletexAPI(API):
 
     client_class = TripletexClient
 
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         """
         Register API endpoints.
         """
@@ -25,7 +25,7 @@ class TripletexAPI(API):
         self.suppliers = TripletexSuppliers(self.client)
         self.company = TripletexCompany(self.client)
 
-    def _register_groups(self):
+    def _register_groups(self) -> None:
         """
         Register top-level ResourceGroup instances.
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -72,12 +72,12 @@ class MockCrud(Crud[BaseModel]):
 class MockAPI(API):
     client_class = Client
 
-    def _register_endpoints(self):
+    def _register_endpoints(self) -> None:
         if self.client is None:
             raise ValueError("Client is required!")
         self.test_resource: Crud = MockCrud(self.client)
 
-    def _register_groups(self):
+    def _register_groups(self) -> None:
         """
         Implementation of the abstract method to register ResourceGroup instances.
         This mock implementation doesn't register any groups.
@@ -85,7 +85,7 @@ class MockAPI(API):
 
 
 @pytest.fixture
-def standard_data():
+def standard_data() -> Dict[str, str]:
     """Return standard test data for API tests."""
     full_url = "https://api.example.com/v1/test"
     hostname = "https://api.example.com"

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -76,10 +76,10 @@ class TestAPI:
         class FailingAPI(API):
             client_class = None
 
-            def _register_endpoints(self):
+            def _register_endpoints(self) -> None:
                 pass
 
-            def _register_groups(self):
+            def _register_groups(self) -> None:
                 pass
 
         client_config = ClientConfig(hostname=standard_data.get("hostname"))
@@ -166,10 +166,10 @@ class TestAPI:
         class ErrorAPI(API):
             client_class = ErrorClient
 
-            def _register_endpoints(self):
+            def _register_endpoints(self) -> None:
                 pass
 
-            def _register_groups(self):
+            def _register_groups(self) -> None:
                 pass
 
         client_config = ClientConfig(hostname="https://api.example.com")


### PR DESCRIPTION
## Summary
- annotate `_register_endpoints` and `_register_groups` methods as returning `None`
- type hint `standard_data` fixture

## Testing
- `pre-commit run --files crudclient/__init__.py crudclient/api.py tests/integration/fiken_resources/setup.py tests/integration/oneflow_resources/setup.py tests/integration/tripletex_resources/api.py tests/unit/api/conftest.py tests/unit/api/test_api.py`
- `pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bfef73b083329b0294d1f19949da