### PR TITLE
Improve typing in test fixtures

### DIFF
--- a/tests/unit/auth/conftest.py
+++ b/tests/unit/auth/conftest.py
@@ -2,13 +2,18 @@
 Fixtures specific to authentication tests.
 """
 
-from typing import Optional
+from typing import Generator, Optional, Type
 from unittest.mock import MagicMock
 
 import pytest
 import requests_mock
+from apiconfig.testing.auth_verification import (
+    AuthHeaderVerification,
+    AuthTestHelpers,
+)
 from apiconfig.testing.unit import create_valid_client_config
 
+from crudclient.auth import AuthStrategy
 from crudclient.client import Client
 from crudclient.config import ClientConfig
 from crudclient.testing.auth import (
@@ -21,7 +26,11 @@ DEFAULT_HOSTNAME = "https://api.example.com"
 DEFAULT_VERSION = "v1"
 
 
-def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
+class Helpers(AuthHeaderVerification, AuthTestHelpers):
+    """Combine auth verification mixins for convenience in tests."""
+
+
+def _build_config(auth_strategy: AuthStrategy, headers: Optional[dict] = None) -> ClientConfig:
     base_config = create_valid_client_config(
         hostname=DEFAULT_HOSTNAME,
         version=DEFAULT_VERSION,
@@ -106,21 +115,13 @@ def apikey_param_client(apikey_param_config: ClientConfig) -> Client:
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Generator[requests_mock.Mocker, None, None]:
     """Create a requests_mock for testing."""
     with requests_mock.Mocker() as m:
         yield m
 
 
 @pytest.fixture
-def mock_auth_verification():
+def mock_auth_verification() -> Generator[Type["Helpers"], None, None]:
     """Provide auth verification helpers from apiconfig."""
-    from apiconfig.testing.auth_verification import (
-        AuthHeaderVerification,
-        AuthTestHelpers,
-    )
-
-    class Helpers(AuthHeaderVerification, AuthTestHelpers):
-        pass
-
     yield Helpers

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -2,13 +2,13 @@
 Fixtures specific to client tests.
 """
 
-from typing import Optional
+from typing import Generator, Optional
 
 import pytest
 import requests_mock
 from apiconfig.testing.unit import create_valid_client_config
 
-from crudclient.auth import BasicAuth, BearerAuth, CustomAuth
+from crudclient.auth import AuthStrategy, BasicAuth, BearerAuth, CustomAuth
 from crudclient.client import Client
 from crudclient.config import ClientConfig
 
@@ -16,7 +16,7 @@ DEFAULT_HOSTNAME = "https://api.example.com"
 DEFAULT_VERSION = "v1"
 
 
-def _build_config(auth_strategy, headers: Optional[dict] = None) -> ClientConfig:
+def _build_config(auth_strategy: AuthStrategy, headers: Optional[dict] = None) -> ClientConfig:
     base_config = create_valid_client_config(
         hostname=DEFAULT_HOSTNAME,
         version=DEFAULT_VERSION,
@@ -58,7 +58,7 @@ def client(bearer_auth_config: ClientConfig) -> Client:
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Generator[requests_mock.Mocker, None, None]:
     """Create a requests_mock for testing."""
     with requests_mock.Mocker() as m:
         yield m

--- a/tests/unit/http/errors/conftest.py
+++ b/tests/unit/http/errors/conftest.py
@@ -2,6 +2,8 @@
 Shared fixtures and utilities for HTTP client error tests.
 """
 
+from typing import Generator
+
 import pytest
 import requests_mock
 from apiconfig.testing.unit import create_valid_client_config
@@ -33,7 +35,7 @@ def http_client(config):
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Generator[requests_mock.Mocker, None, None]:
     """Fixture for mocking HTTP requests."""
     with requests_mock.Mocker() as m:
         yield m


### PR DESCRIPTION
## Summary
- tighten typing for `_build_config` helper functions
- specify generator return types for `mock_request` and `mock_auth_verification`

## Testing
- `poetry run pre-commit run --files tests/unit/auth/conftest.py tests/unit/client/conftest.py tests/unit/http/errors/conftest.py`
- `poetry run pre-commit run --hook-stage push --files tests/unit/auth/conftest.py tests/unit/client/conftest.py tests/unit/http/errors/conftest.py`
- `poetry run pytest -q` *(fails: crudclient.exceptions.ConnectionError: Could not connect to host)*

------
https://chatgpt.com/codex/tasks/task_e_6865bfeeb2b083328dba0310c766fc25