### PR TITLE
Fix test annotations

### DIFF
--- a/tests/unit/http/test_http_logging_request.py
+++ b/tests/unit/http/test_http_logging_request.py
@@ -41,7 +41,7 @@ def test_log_request_details_base(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify basic request details logging (method, URL, headers)."""
     method = mock_prepared_request.method
     url = mock_prepared_request.url
@@ -67,7 +67,7 @@ def test_log_request_details_no_params(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request details logging when no params are present."""
     method = mock_prepared_request.method
     url = mock_prepared_request.url
@@ -87,7 +87,7 @@ def test_log_request_details_with_body_enabled(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request body logging when log_request_body is True."""
     mock_client_config.log_request_body = True  # Enable body logging
     method = mock_prepared_request.method
@@ -116,7 +116,7 @@ def test_log_request_details_with_long_body_truncated(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request body truncation."""
     mock_client_config.log_request_body = True
     method = mock_prepared_request.method
@@ -160,7 +160,7 @@ def test_log_request_details_with_data_kwarg(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify logging when 'data' kwarg is used instead of 'json'."""
     mock_client_config.log_request_body = True
     method = mock_prepared_request.method
@@ -187,7 +187,7 @@ def test_log_request_details_header_redaction(
     mock_client_config: MagicMock,  # Use config directly
     caplog: pytest.LogCaptureFixture,
     # mock_prepared_request: MagicMock, # Not needed as we define headers directly
-):
+) -> None:
     """Verify sensitive headers are redacted in logs using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_header_redaction")
@@ -236,7 +236,7 @@ def test_log_request_details_body_redaction_simple(
     # http_logger: HttpLifecycleLogger, # Remove fixture
     caplog: pytest.LogCaptureFixture,
     mock_client_config: MagicMock,  # Fixture from conftest.py
-):
+) -> None:
     """Verify simple sensitive keys in JSON body are redacted using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_body_redaction_simple")
@@ -289,7 +289,7 @@ def test_log_request_details_body_redaction_nested(
     # http_logger: HttpLifecycleLogger, # Remove fixture
     caplog: pytest.LogCaptureFixture,
     mock_client_config: MagicMock,  # Fixture from conftest.py
-):
+) -> None:
     """Verify nested sensitive keys in JSON body are redacted using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_body_redaction_nested")

--- a/tests/unit/http/test_http_logging_response.py
+++ b/tests/unit/http/test_http_logging_response.py
@@ -68,7 +68,7 @@ def test_log_response_details_base(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,
-):
+) -> None:
     """Verify basic response details logging (status, headers)."""
     method = mock_response.request.method
     url = mock_response.request.url
@@ -88,7 +88,7 @@ def test_log_response_details_error_status(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,
-):
+) -> None:
     """Verify warning/error logging for non-2xx status codes."""
     method = mock_response.request.method
     url = mock_response.request.url
@@ -114,7 +114,7 @@ def test_log_response_details_with_body_enabled(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify response body logging when log_response_body is True."""
     mock_client_config.log_response_body = True  # Enable body logging
     method = mock_response.request.method
@@ -153,7 +153,7 @@ def test_log_response_details_with_long_body_truncated(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify response body truncation."""
     mock_client_config.log_response_body = True
     method = mock_response.request.method
@@ -205,7 +205,7 @@ def test_log_response_details_non_json_body(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify logging for non-JSON response bodies."""
     mock_client_config.log_response_body = True
     method = mock_response.request.method

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,7 +1,7 @@
 # tests/unit/test_logging_config.py
 import io
 import logging
-from typing import Any, Generator
+from typing import Generator
 
 import pytest
 
@@ -41,7 +41,7 @@ def ensure_logging_cleanup() -> Generator[None, None, None]:
     # logging.getLogger().handlers = [] # Be careful with global root logger
 
 
-def test_logging_default_configuration(caplog: Any) -> None:
+def test_logging_default_configuration(caplog: pytest.LogCaptureFixture) -> None:
     """Verify the default logging configuration for the library.
 
     - No handlers attached directly to the library logger (or only NullHandler).
@@ -73,7 +73,7 @@ def test_logging_default_configuration(caplog: Any) -> None:
     assert "Default: Crud warning message." in caplog.text
 
 
-def test_logging_set_level_root(caplog: Any) -> None:
+def test_logging_set_level_root(caplog: pytest.LogCaptureFixture) -> None:
     """Verify setting the level on the root crudclient logger captures messages."""
     # Add caplog's handler to the crudclient logger
     # No need to explicitly add handler, caplog does this implicitly
@@ -94,7 +94,7 @@ def test_logging_set_level_root(caplog: Any) -> None:
     assert "HTTP debug message via root." in caplog.text
 
 
-def test_logging_set_level_sub_logger(caplog: Any) -> None:
+def test_logging_set_level_sub_logger(caplog: pytest.LogCaptureFixture) -> None:
     """Verify setting a different level on a sub-logger filters correctly."""
     # Set root to DEBUG, but sub-logger to INFO
     caplog.set_level(logging.DEBUG, logger="crudclient")  # Capture everything from root

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -25,7 +25,7 @@ from crudclient.http.utils import redact_json_body
 def test_log_response_body_redaction_simple(
     mock_client_config: MagicMock,  # Use the imported fixture type
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Verify simple sensitive keys in JSON response body are redacted."""
     mock_client_config.log_response_body = True  # Enable body logging
     caplog.set_level("DEBUG")
@@ -75,7 +75,7 @@ def test_log_response_body_redaction_simple(
 def test_log_response_body_redaction_nested_list(
     mock_client_config: MagicMock,  # Use the imported fixture type
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Verify sensitive keys in nested lists within response body are redacted."""
     mock_client_config.log_response_body = True  # Enable body logging
     caplog.set_level("DEBUG")
@@ -138,7 +138,7 @@ class SensitiveModel(BaseModel):
 # Removed defunct test_data_validation_error_log_redaction
 
 
-def test_data_validation_error_exception_redaction():
+def test_data_validation_error_exception_redaction() -> None:
     """Verify sensitive data is redacted in DataValidationError exception attributes."""
     invalid_data = {
         "user_id": "not-an-int",


### PR DESCRIPTION
## Summary
- mark more tests with return type `-> None`
- annotate logging tests with `pytest.LogCaptureFixture`

## Testing
- `pre-commit run --files tests/unit/test_logging_config.py tests/unit/test_redaction.py tests/unit/http/test_http_logging_request.py tests/unit/http/test_http_logging_response.py`
- `poetry run pytest -q` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865bfd6c3cc8332b2d399f0e4135fc4