### PR TITLE
Add typing to tests

### DIFF
--- a/tests/integration/test_fiken.py
+++ b/tests/integration/test_fiken.py
@@ -6,12 +6,12 @@ from .fiken_resources.setup import Company, Contact, FikenAPI, FikenConfig, User
 
 
 @pytest.fixture
-def api():
+def api() -> FikenAPI:
     config = FikenConfig()
     return FikenAPI(client_config=config)
 
 
-def test_api_configuration(api):
+def test_api_configuration(api: FikenAPI) -> None:
     assert api.client.base_url == "https://api.fiken.no/api/v2"
 
     # Skip auth tests if no token is provided
@@ -29,14 +29,14 @@ def test_api_configuration(api):
         assert api.client.config.auth_strategy.access_token != ""
 
 
-def test_retrive_user(api):
+def test_retrive_user(api: FikenAPI) -> None:
     user = api.user.read()
     assert isinstance(user, User)
     assert user.name is not None
     assert user.email is not None
 
 
-def test_list_companies(api):
+def test_list_companies(api: FikenAPI) -> None:
     companies = api.companies.list()
 
     assert isinstance(companies, list)
@@ -44,7 +44,7 @@ def test_list_companies(api):
     assert all(isinstance(company, Company) for company in companies)
 
 
-def test_list_contacts(api):
+def test_list_contacts(api: FikenAPI) -> None:
     contacts = api.contacts.bind_company("fiken-demo-faktisk-plante-as2").list()
     assert isinstance(contacts, list)
     assert len(contacts) > 0

--- a/tests/integration/test_tripletex.py
+++ b/tests/integration/test_tripletex.py
@@ -11,7 +11,7 @@ from .tripletex_resources.models.api_response_model import TripletexResponse
 
 
 @pytest.fixture
-def api():
+def api() -> TripletexAPI:
     """
     Create a Tripletex API client for testing.
     """
@@ -19,7 +19,7 @@ def api():
     return TripletexAPI(client_config=config)
 
 
-def test_api_configuration(api):
+def test_api_configuration(api: TripletexAPI) -> None:
     """
     Test that the API client is configured correctly.
     """
@@ -45,7 +45,7 @@ def test_api_configuration(api):
 
 
 @pytest.mark.no_parallel
-def test_token_refresh(api):
+def test_token_refresh(api: TripletexAPI) -> None:
     """
     Test that the token can be refreshed.
     """
@@ -61,7 +61,7 @@ def test_token_refresh(api):
     assert new_token != old_token
 
 
-def test_auth_headers(api):
+def test_auth_headers(api: TripletexAPI) -> None:
     """
     Test that the authentication headers are correctly generated.
     """
@@ -74,7 +74,7 @@ def test_auth_headers(api):
     assert len(headers["Authorization"]) > 10  # Basic + space + base64 encoded string
 
 
-def test_list_countries(api):
+def test_list_countries(api: TripletexAPI) -> None:
     """
     Test that we can list countries from the Tripletex API.
     """
@@ -98,7 +98,7 @@ def test_list_countries(api):
         assert hasattr(country, "displayName")
 
 
-def test_read_country(api):
+def test_read_country(api: TripletexAPI) -> None:
     """
     Test that we can read a specific country from the Tripletex API.
     """

--- a/tests/integration/test_tripletex_company.py
+++ b/tests/integration/test_tripletex_company.py
@@ -9,7 +9,7 @@ from .tripletex_resources import TripletexAPI, TripletexTestConfig
 
 
 @pytest.fixture
-def api():
+def api() -> TripletexAPI:
     """
     Create a Tripletex API client for testing.
     """
@@ -29,7 +29,7 @@ def generate_unique_name():
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_update_company_minimal(api):
+def test_update_company_minimal(api: TripletexAPI) -> None:
     """
     Test updating a company with minimal data.
 

--- a/tests/integration/test_tripletex_ledger_nested.py
+++ b/tests/integration/test_tripletex_ledger_nested.py
@@ -16,7 +16,7 @@ from .tripletex_resources.models import (
 
 
 @pytest.fixture
-def api():
+def api() -> TripletexAPI:
     """
     Create a Tripletex API client for testing.
     """
@@ -37,7 +37,7 @@ def get_dates():
     return date_from, date_to
 
 
-def test_api_ledger_group_registration(api):
+def test_api_ledger_group_registration(api: TripletexAPI) -> None:
     """
     Test that the LedgerGroup is properly registered in the API.
     """
@@ -51,7 +51,7 @@ def test_api_ledger_group_registration(api):
     assert hasattr(api.ledger.voucher, "historical")
 
 
-def test_list_ledgers(api):
+def test_list_ledgers(api: TripletexAPI) -> None:
     """
     Test listing ledgers from the Tripletex API using ResourceGroup.
     """
@@ -78,7 +78,7 @@ def test_list_ledgers(api):
             assert hasattr(ledger, "closing_balance")
 
 
-def test_read_ledger(api):
+def test_read_ledger(api: TripletexAPI) -> None:
     """
     Test reading a specific ledger from the Tripletex API using ResourceGroup.
     """
@@ -106,7 +106,7 @@ def test_read_ledger(api):
     assert hasattr(first_ledger, "closing_balance")
 
 
-def test_list_vouchers(api):
+def test_list_vouchers(api: TripletexAPI) -> None:
     """
     Test listing vouchers from the Tripletex API using nested ResourceGroup.
     """
@@ -131,7 +131,7 @@ def test_list_vouchers(api):
             assert hasattr(voucher, "description")
 
 
-def test_read_voucher(api):
+def test_read_voucher(api: TripletexAPI) -> None:
     """
     Test reading a specific voucher from the Tripletex API using nested ResourceGroup.
     """

--- a/tests/integration/test_tripletex_rate_limiting_live.py
+++ b/tests/integration/test_tripletex_rate_limiting_live.py
@@ -32,7 +32,7 @@ logging.getLogger("crudclient.ratelimit").setLevel(logging.DEBUG)
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_tripletex_rate_limiting_prevents_429():
+def test_tripletex_rate_limiting_prevents_429() -> None:
     """
     Test that rate limiter prevents 429 errors under real rate limit conditions.
 
@@ -167,7 +167,7 @@ def test_tripletex_rate_limiting_prevents_429():
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_rate_limiter_delay_tracking():
+def test_rate_limiter_delay_tracking() -> None:
     """Test that the rate limiter delay tracking mechanism works correctly."""
 
     print("\n=== Testing rate limiter delay tracking ===")

--- a/tests/integration/test_tripletex_suppliers.py
+++ b/tests/integration/test_tripletex_suppliers.py
@@ -2,12 +2,13 @@ import os
 
 import pytest
 
+from .tripletex_resources.api import TripletexAPI
 from .tripletex_resources.models.api_response_model import TripletexResponse
 from .tripletex_resources.models.supplier import Supplier
 
 
 @pytest.mark.no_parallel
-def test_list_suppliers(api):
+def test_list_suppliers(api: TripletexAPI) -> None:
     """
     Test listing suppliers.
     """
@@ -28,7 +29,12 @@ def test_list_suppliers(api):
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_create_update_destroy_supplier(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_create_update_destroy_supplier(
+    api: TripletexAPI,
+    unique_supplier_name: str,
+    find_unused_supplier_number,
+    supplier_tracker,
+) -> None:
     """
     Test creating, updating, and destroying a supplier.
     Uses fixtures for reliable cleanup and unique naming.
@@ -95,7 +101,12 @@ def test_create_update_destroy_supplier(api, unique_supplier_name, find_unused_s
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_supplier_number_uniqueness(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_supplier_number_uniqueness(
+    api: TripletexAPI,
+    unique_supplier_name: str,
+    find_unused_supplier_number,
+    supplier_tracker,
+) -> None:
     """
     Test supplier number handling - either enforces uniqueness or allows duplicates.
     This test adapts to the API's behavior.
@@ -144,7 +155,12 @@ def test_supplier_number_uniqueness(api, unique_supplier_name, find_unused_suppl
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_multiple_suppliers_cleanup(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_multiple_suppliers_cleanup(
+    api: TripletexAPI,
+    unique_supplier_name: str,
+    find_unused_supplier_number,
+    supplier_tracker,
+) -> None:
     """
     Test creating multiple suppliers and ensuring they're all cleaned up.
     This tests the robustness of our cleanup mechanism.

--- a/tests/unit/auth/test_auth_verification_helpers.py
+++ b/tests/unit/auth/test_auth_verification_helpers.py
@@ -1,11 +1,13 @@
 import pytest
 from apiconfig.exceptions.auth import AuthenticationError
 
+from crudclient.client import Client
+
 
 class TestAuthVerificationHelpers:
     """Tests for authentication verification helpers."""
 
-    def test_verify_basic_auth_header(self, basic_auth_client, mock_auth_verification):
+    def test_verify_basic_auth_header(self, basic_auth_client: Client, mock_auth_verification) -> None:
         """Test verification of Basic Auth headers."""
         # Arrange
         auth_strategy = basic_auth_client.config.auth_strategy
@@ -18,7 +20,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_basic_auth_header("NotBasic xyz")
 
-    def test_verify_bearer_auth_header(self, bearer_auth_client, mock_auth_verification):
+    def test_verify_bearer_auth_header(self, bearer_auth_client: Client, mock_auth_verification) -> None:
         """Test verification of Bearer Auth headers."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -31,7 +33,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_bearer_auth_header("NotBearer xyz")
 
-    def test_assert_auth_header_format(self, bearer_auth_client, mock_auth_verification):
+    def test_assert_auth_header_format(self, bearer_auth_client: Client, mock_auth_verification) -> None:
         """Test assertion of auth header format."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -44,7 +46,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_auth_header_format({"Authorization": "Invalid format"}, "bearer")
 
-    def test_assert_token_usage(self, bearer_auth_client, mock_auth_verification):
+    def test_assert_token_usage(self, bearer_auth_client: Client, mock_auth_verification) -> None:
         """Test assertion of token usage."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -57,7 +59,7 @@ class TestAuthVerificationHelpers:
         # call it separately without expecting it to compare values.
         # mock_auth_verification.assert_token_usage(token) # Example: Check JWT validity if needed
 
-    def test_assert_refresh_behavior(self, mock_auth_verification):
+    def test_assert_refresh_behavior(self, mock_auth_verification) -> None:
         """Test assertion of token refresh behavior."""
         # Arrange
         old_headers = {"Authorization": "Bearer old_token"}

--- a/tests/unit/auth/test_basic_auth_failures.py
+++ b/tests/unit/auth/test_basic_auth_failures.py
@@ -7,10 +7,11 @@ from typing import cast
 import pytest
 import requests
 
+from crudclient.client import Client
 from crudclient.exceptions import AuthenticationError
 
 
-def test_basic_auth_failure(basic_auth_client, mock_request):
+def test_basic_auth_failure(basic_auth_client: Client, mock_request) -> None:
     """Test handling of Basic Authentication failures."""
     url = f"{basic_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid credentials"})

--- a/tests/unit/auth/test_bearer_auth_failures.py
+++ b/tests/unit/auth/test_bearer_auth_failures.py
@@ -8,10 +8,11 @@ from typing import cast
 import pytest
 import requests
 
+from crudclient.client import Client
 from crudclient.exceptions import AuthenticationError, ForbiddenError
 
 
-def test_bearer_auth_failure(bearer_auth_client, mock_request):
+def test_bearer_auth_failure(bearer_auth_client: Client, mock_request) -> None:
     """Test handling of Bearer Authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -30,7 +31,7 @@ def test_bearer_auth_failure(bearer_auth_client, mock_request):
     assert request.headers["Authorization"] == "Bearer valid_token"
 
 
-def test_token_refresh_on_401(refreshable_token_client, mock_request):
+def test_token_refresh_on_401(refreshable_token_client: Client, mock_request) -> None:
     """Test token refresh on 401 Unauthorized responses."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Token expired"})
@@ -51,7 +52,7 @@ def test_token_refresh_on_401(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Token expired"
 
 
-def test_token_refresh_on_403(refreshable_token_client, mock_request):
+def test_token_refresh_on_403(refreshable_token_client: Client, mock_request) -> None:
     """Test token refresh on 403 Forbidden responses."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=403, json={"error": "Forbidden", "message": "Insufficient permissions"})
@@ -66,7 +67,7 @@ def test_token_refresh_on_403(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Insufficient permissions"
 
 
-def test_token_refresh_failure(refreshable_token_client, mock_request):
+def test_token_refresh_failure(refreshable_token_client: Client, mock_request) -> None:
     """Test handling of token refresh failures."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Token expired"})
@@ -85,7 +86,7 @@ def test_token_refresh_failure(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Token expired"
 
 
-def test_retry_after_auth_failure(bearer_auth_client, mock_request):
+def test_retry_after_auth_failure(bearer_auth_client: Client, mock_request) -> None:
     """Test retry behavior after authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -100,7 +101,7 @@ def test_retry_after_auth_failure(bearer_auth_client, mock_request):
     assert response.json()["message"] == "Invalid token"
 
 
-def test_auth_failure_with_retry_disabled(bearer_auth_client, mock_request):
+def test_auth_failure_with_retry_disabled(bearer_auth_client: Client, mock_request) -> None:
     """Test handling of authentication failures with retry disabled."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -115,7 +116,7 @@ def test_auth_failure_with_retry_disabled(bearer_auth_client, mock_request):
     assert response.json()["message"] == "Invalid token"
 
 
-def test_auth_header_overriding(bearer_auth_client, mock_request):
+def test_auth_header_overriding(bearer_auth_client: Client, mock_request) -> None:
     """Test that authentication headers can be overridden."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, json={"data": "success"})
@@ -131,7 +132,7 @@ def test_auth_header_overriding(bearer_auth_client, mock_request):
     bearer_auth_client.http_client.session_manager.session.headers = original_headers
 
 
-def test_auth_header_merging(bearer_auth_client, mock_request):
+def test_auth_header_merging(bearer_auth_client: Client, mock_request) -> None:
     """Test that authentication headers are merged with custom headers."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, json={"data": "success"})
@@ -148,7 +149,7 @@ def test_auth_header_merging(bearer_auth_client, mock_request):
     bearer_auth_client.http_client.session_manager.session.headers = original_headers
 
 
-def test_multiple_auth_failures(bearer_auth_client, mock_request):
+def test_multiple_auth_failures(bearer_auth_client: Client, mock_request) -> None:
     """Test handling of multiple authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})

--- a/tests/unit/auth/test_custom_auth_failures.py
+++ b/tests/unit/auth/test_custom_auth_failures.py
@@ -11,7 +11,7 @@ from crudclient.config import ClientConfig
 from crudclient.exceptions import AuthenticationError
 
 
-def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test handling of custom authentication failures during setup."""
 
     def header_callback():
@@ -29,7 +29,7 @@ def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig):
     assert "Failed to generate custom header" in str(excinfo.value.__cause__)
 
 
-def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test that exceptions from param_callback are propagated."""
 
     def failing_param_callback() -> dict:
@@ -43,7 +43,7 @@ def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: Cli
         client.get("/some/path")
 
 
-def test_custom_auth_api_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_api_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test handling of API returning 401/403 with CustomAuth."""
 
     def get_headers():

--- a/tests/unit/client/test_client_auth.py
+++ b/tests/unit/client/test_client_auth.py
@@ -7,7 +7,7 @@ from crudclient.config import ClientConfig
 
 class TestClientAuth:
 
-    def test_client_accepts_dict_config(self):
+    def test_client_accepts_dict_config(self) -> None:
         # Arrange
         config_dict = {
             "hostname": "https://example.com",
@@ -23,7 +23,7 @@ class TestClientAuth:
         assert client.config.version == "v1"
         assert client.session.headers["X-Test"] == "1"
 
-    def test_client_basic_auth_sets_session_headers(self, basic_auth_config: ClientConfig):
+    def test_client_basic_auth_sets_session_headers(self, basic_auth_config: ClientConfig) -> None:
         # Arrange
         config = basic_auth_config
 
@@ -34,7 +34,7 @@ class TestClientAuth:
         # Just check that the Authorization header exists
         assert "Authorization" in client.session.headers
 
-    def test_client_custom_auth_applies_headers(self, custom_auth_config: ClientConfig):
+    def test_client_custom_auth_applies_headers(self, custom_auth_config: ClientConfig) -> None:
         # Arrange
         config = custom_auth_config
 
@@ -44,7 +44,7 @@ class TestClientAuth:
         # Assert
         assert client.session.headers["X-Auth"] == "yes"
 
-    def test_client_bearer_token_auth_sets_session_headers(self):
+    def test_client_bearer_token_auth_sets_session_headers(self) -> None:
         """Test Client initialization with BearerTokenAuth sets the correct header."""
         # Arrange
         token = "my-secret-token"


### PR DESCRIPTION
## Summary
- annotate test methods to return None
- type fixture parameters where appropriate

## Testing
- `poetry run pre-commit run --files tests/integration/test_fiken.py tests/integration/test_tripletex.py tests/integration/test_tripletex_company.py tests/integration/test_tripletex_ledger_nested.py tests/integration/test_tripletex_rate_limiting_live.py tests/integration/test_tripletex_suppliers.py tests/unit/auth/test_auth_verification_helpers.py tests/unit/auth/test_basic_auth_failures.py tests/unit/auth/test_bearer_auth_failures.py tests/unit/auth/test_custom_auth_failures.py tests/unit/client/test_client_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6865bfd5475c8332a2d965d87c470454