### PR TITLE
Add typing for error test fixtures

### DIFF
--- a/tests/unit/auth/conftest.py
+++ b/tests/unit/auth/conftest.py
@@ -2,7 +2,7 @@
 Fixtures specific to authentication tests.
 """
 
-from typing import Optional
+from typing import Iterator, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -106,7 +106,7 @@ def apikey_param_client(apikey_param_config: ClientConfig) -> Client:
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Iterator[requests_mock.Mocker]:
     """Create a requests_mock for testing."""
     with requests_mock.Mocker() as m:
         yield m

--- a/tests/unit/client/conftest.py
+++ b/tests/unit/client/conftest.py
@@ -2,7 +2,7 @@
 Fixtures specific to client tests.
 """
 
-from typing import Optional
+from typing import Iterator, Optional
 
 import pytest
 import requests_mock
@@ -58,7 +58,7 @@ def client(bearer_auth_config: ClientConfig) -> Client:
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Iterator[requests_mock.Mocker]:
     """Create a requests_mock for testing."""
     with requests_mock.Mocker() as m:
         yield m

--- a/tests/unit/http/errors/conftest.py
+++ b/tests/unit/http/errors/conftest.py
@@ -2,6 +2,8 @@
 Shared fixtures and utilities for HTTP client error tests.
 """
 
+from typing import Iterator
+
 import pytest
 import requests_mock
 from apiconfig.testing.unit import create_valid_client_config
@@ -11,7 +13,7 @@ from crudclient.http.client import HttpClient
 
 
 @pytest.fixture
-def config():
+def config() -> ClientConfig:
     """Fixture for a mock configuration."""
     base_config = create_valid_client_config(timeout=5, retries=0, auth_strategy=None)
     return ClientConfig(
@@ -27,13 +29,13 @@ def config():
 
 
 @pytest.fixture
-def http_client(config):
+def http_client(config: ClientConfig) -> HttpClient:
     """Fixture for an HTTP client."""
     return HttpClient(config)
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> Iterator[requests_mock.Mocker]:
     """Fixture for mocking HTTP requests."""
     with requests_mock.Mocker() as m:
         yield m

--- a/tests/unit/http/errors/test_client_errors.py
+++ b/tests/unit/http/errors/test_client_errors.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
 from crudclient.exceptions import (
     APIError,
@@ -17,12 +18,13 @@ from crudclient.exceptions import (
     NotFoundError,
     UnprocessableEntityError,
 )
+from crudclient.http.client import HttpClient
 
 
 class TestHttpClientClientErrors:
     """Tests for handling client errors in the HTTP client."""
 
-    def test_400_error(self, http_client, mock_request):
+    def test_400_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 400 Bad Request.
 
@@ -41,7 +43,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid parameters"
 
-    def test_401_error(self, http_client, mock_request):
+    def test_401_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 401 Unauthorized.
 
@@ -60,7 +62,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Authentication required"
 
-    def test_403_error(self, http_client, mock_request):
+    def test_403_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 403 Forbidden.
 
@@ -79,7 +81,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Insufficient permissions"
 
-    def test_404_error(self, http_client, mock_request):
+    def test_404_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 404 Not Found.
 
@@ -98,7 +100,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Resource not found"
 
-    def test_422_error(self, http_client, mock_request):
+    def test_422_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 422 Unprocessable Entity.
 
@@ -117,7 +119,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Validation failed"
 
-    def test_429_error(self, http_client, mock_request):
+    def test_429_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 429 Too Many Requests.
 

--- a/tests/unit/http/errors/test_malformed_responses.py
+++ b/tests/unit/http/errors/test_malformed_responses.py
@@ -8,14 +8,16 @@ content types.
 
 import pytest
 import requests
+import requests_mock
 
 from crudclient.exceptions import ResponseParsingError
+from crudclient.http.client import HttpClient
 
 
 class TestHttpClientMalformedResponses:
     """Tests for handling malformed responses in the HTTP client."""
 
-    def test_malformed_json_response(self, http_client, mock_request):
+    def test_malformed_json_response(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of malformed JSON responses.
 
@@ -34,7 +36,7 @@ class TestHttpClientMalformedResponses:
         assert isinstance(excinfo.value.original_exception, requests.exceptions.JSONDecodeError)
         assert "Expecting value" in str(excinfo.value.original_exception)
 
-    def test_empty_response(self, http_client, mock_request):
+    def test_empty_response(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of empty responses.
 
@@ -49,7 +51,7 @@ class TestHttpClientMalformedResponses:
         response = http_client.get("/users")
         assert response is None or response == ""
 
-    def test_non_json_content_type(self, http_client, mock_request):
+    def test_non_json_content_type(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of non-JSON content types.
 
@@ -64,7 +66,7 @@ class TestHttpClientMalformedResponses:
         response = http_client.get("/users")
         assert response == "<html>Not JSON</html>"
 
-    def test_unexpected_content_type(self, http_client, mock_request):
+    def test_unexpected_content_type(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of unexpected content types.
 

--- a/tests/unit/http/errors/test_server_errors.py
+++ b/tests/unit/http/errors/test_server_errors.py
@@ -9,14 +9,16 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
 from crudclient.exceptions import APIError
+from crudclient.http.client import HttpClient
 
 
 class TestHttpClientServerErrors:
     """Tests for handling server errors in the HTTP client."""
 
-    def test_500_error(self, http_client, mock_request):
+    def test_500_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 500 Internal Server Error.
 
@@ -35,7 +37,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Something went wrong"
 
-    def test_502_error(self, http_client, mock_request):
+    def test_502_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 502 Bad Gateway.
 
@@ -54,7 +56,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid response from upstream server"
 
-    def test_503_error(self, http_client, mock_request):
+    def test_503_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 503 Service Unavailable.
 
@@ -73,7 +75,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Server is overloaded"
 
-    def test_504_error(self, http_client, mock_request):
+    def test_504_error(self, http_client: HttpClient, mock_request: requests_mock.Mocker) -> None:
         """
         Test handling of 504 Gateway Timeout.
 


### PR DESCRIPTION
## Summary
- add type hints for `http_client` and `mock_request` fixtures
- annotate HTTP error tests with fixture types and return `None`
- run project formatters and test suite

## Testing
- `poetry run isort . --profile black --skip-glob="**/apiconfig/*" --check`
- `poetry run black . --extend-exclude="apiconfig/" --check`
- `poetry run flake8`
- `poetry run mypy --config-file mypy.ini --disallow-untyped-defs`
- `poetry run pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_6865bfd4e63883328b6f659dabec0a38