### PR TITLE
Add return types and variable hints in MockClient tests

### DIFF
--- a/tests/unit/testing/core/test_client_initialization.py
+++ b/tests/unit/testing/core/test_client_initialization.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 
-from crudclient.auth import BearerAuth
+from typing import Optional
+
+from crudclient.auth import AuthStrategy, BearerAuth
 from crudclient.testing.core.client import MockClient
 from crudclient.testing.verification import Verifier
 from tests.unit.helpers import translate_mock_calls_for_verifier
@@ -9,14 +11,14 @@ from tests.unit.helpers import translate_mock_calls_for_verifier
 class TestMockClientInitialization:
     """Tests for the initialization and configuration of MockClient."""
 
-    def test_init(self):
+    def test_init(self) -> None:
         """Test initialization of MockClient."""
         # Arrange
-        http_client = MagicMock()
-        base_url = "https://test.example.com"
+        http_client: MagicMock = MagicMock()
+        base_url: str = "https://test.example.com"
 
         # Act
-        client = MockClient(http_client, base_url=base_url)
+        client: MockClient = MockClient(http_client, base_url=base_url)
 
         # Assert
         assert client.http_client == http_client
@@ -25,11 +27,11 @@ class TestMockClientInitialization:
         assert client.get_call_count() == 0
         assert client._auth_strategy is None
 
-    def test_configure_response(self):
+    def test_configure_response(self) -> None:
         """Test configure_response method."""
         # Arrange
-        http_client = MagicMock()
-        client = MockClient(http_client)
+        http_client: MagicMock = MagicMock()
+        client: MockClient = MockClient(http_client)
 
         # Act
         client.configure_response(
@@ -53,12 +55,12 @@ class TestMockClientInitialization:
             error=None,
         )
 
-    def test_set_auth_strategy(self):
+    def test_set_auth_strategy(self) -> None:
         """Test set_auth_strategy method."""
         # Arrange
-        http_client = MagicMock()
-        client = MockClient(http_client)
-        auth_strategy = BearerAuth(access_token="test-token")
+        http_client: MagicMock = MagicMock()
+        client: MockClient = MockClient(http_client)
+        auth_strategy: BearerAuth = BearerAuth(access_token="test-token")
 
         # Act
         client.set_auth_strategy(auth_strategy)
@@ -67,16 +69,16 @@ class TestMockClientInitialization:
         assert client._auth_strategy == auth_strategy
         assert client.config.auth_strategy == auth_strategy
 
-    def test_get_auth_strategy(self):
+    def test_get_auth_strategy(self) -> None:
         """Test get_auth_strategy method."""
         # Arrange
-        http_client = MagicMock()
-        client = MockClient(http_client)
-        auth_strategy = BearerAuth(access_token="test-token")
+        http_client: MagicMock = MagicMock()
+        client: MockClient = MockClient(http_client)
+        auth_strategy: BearerAuth = BearerAuth(access_token="test-token")
         client.set_auth_strategy(auth_strategy)
 
         # Act
-        result = client.get_auth_strategy()
+        result: Optional[AuthStrategy] = client.get_auth_strategy()
 
         # Assert
         assert result == auth_strategy


### PR DESCRIPTION
## Summary
- annotate MockClient tests with return types and local variable types

## Testing
- `mypy tests/unit/testing/core/test_client_initialization.py`
- `mypy .`
- `pre-commit run --files tests/unit/testing/core/test_client_initialization.py` *(fails: `pre-commit` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'xdist')*

------
https://chatgpt.com/codex/tasks/task_e_6865bfd0d6c48332a1d57817ad5bfb22