### PR TITLE
Add type hints to auth failure tests

### DIFF
--- a/tests/unit/auth/test_auth_failures.py
+++ b/tests/unit/auth/test_auth_failures.py
@@ -3,7 +3,9 @@ Tests for general authentication setup failure handling in the crudclient librar
 """
 
 import pytest
+import requests_mock
 from apiconfig.exceptions.auth import AuthStrategyError
+from pytest_mock import MockerFixture
 
 from crudclient.auth import CustomAuth
 from crudclient.client import Client
@@ -15,7 +17,12 @@ from crudclient.config import ClientConfig
 class TestAuthFailures:
     """Tests for general authentication failure handling."""
 
-    def test_auth_setup_failure(self, mock_request, mocker, bearer_auth_config: ClientConfig):
+    def test_auth_setup_failure(
+        self,
+        mock_request: requests_mock.Mocker,
+        mocker: MockerFixture,
+        bearer_auth_config: ClientConfig,
+    ) -> None:
         """Test handling of authentication setup failures."""
         # Arrange
         # Create a bearer auth mock with a failing callback
@@ -37,7 +44,11 @@ class TestAuthFailures:
         # Check that the exception contains the error details
         assert "Auth setup failed" in str(excinfo.value)
 
-    def test_auth_param_setup_failure(self, mock_request, create_mock_client_config):
+    def test_auth_param_setup_failure(
+        self,
+        mock_request: requests_mock.Mocker,
+        create_mock_client_config,
+    ) -> None:
         """
         Test that exceptions during auth parameter setup are propagated.
 


### PR DESCRIPTION
## Summary
- annotate `mock_request` and `mocker` fixtures in `test_auth_failures`
- add explicit `-> None` return types for test functions

## Testing
- `pre-commit run --files tests/unit/auth/test_auth_failures.py`

------
https://chatgpt.com/codex/tasks/task_e_6865bfcf6cb48332b2770ff3d7fe9002