### PR TITLE
Annotate tests with None return type

### DIFF
--- a/tests/integration/test_fiken.py
+++ b/tests/integration/test_fiken.py
@@ -11,7 +11,7 @@ def api():
     return FikenAPI(client_config=config)
 
 
-def test_api_configuration(api):
+def test_api_configuration(api) -> None:
     assert api.client.base_url == "https://api.fiken.no/api/v2"
 
     # Skip auth tests if no token is provided
@@ -29,14 +29,14 @@ def test_api_configuration(api):
         assert api.client.config.auth_strategy.access_token != ""
 
 
-def test_retrive_user(api):
+def test_retrive_user(api) -> None:
     user = api.user.read()
     assert isinstance(user, User)
     assert user.name is not None
     assert user.email is not None
 
 
-def test_list_companies(api):
+def test_list_companies(api) -> None:
     companies = api.companies.list()
 
     assert isinstance(companies, list)
@@ -44,7 +44,7 @@ def test_list_companies(api):
     assert all(isinstance(company, Company) for company in companies)
 
 
-def test_list_contacts(api):
+def test_list_contacts(api) -> None:
     contacts = api.contacts.bind_company("fiken-demo-faktisk-plante-as2").list()
     assert isinstance(contacts, list)
     assert len(contacts) > 0

--- a/tests/integration/test_tripletex.py
+++ b/tests/integration/test_tripletex.py
@@ -19,7 +19,7 @@ def api():
     return TripletexAPI(client_config=config)
 
 
-def test_api_configuration(api):
+def test_api_configuration(api) -> None:
     """
     Test that the API client is configured correctly.
     """
@@ -45,7 +45,7 @@ def test_api_configuration(api):
 
 
 @pytest.mark.no_parallel
-def test_token_refresh(api):
+def test_token_refresh(api) -> None:
     """
     Test that the token can be refreshed.
     """
@@ -61,7 +61,7 @@ def test_token_refresh(api):
     assert new_token != old_token
 
 
-def test_auth_headers(api):
+def test_auth_headers(api) -> None:
     """
     Test that the authentication headers are correctly generated.
     """
@@ -74,7 +74,7 @@ def test_auth_headers(api):
     assert len(headers["Authorization"]) > 10  # Basic + space + base64 encoded string
 
 
-def test_list_countries(api):
+def test_list_countries(api) -> None:
     """
     Test that we can list countries from the Tripletex API.
     """
@@ -98,7 +98,7 @@ def test_list_countries(api):
         assert hasattr(country, "displayName")
 
 
-def test_read_country(api):
+def test_read_country(api) -> None:
     """
     Test that we can read a specific country from the Tripletex API.
     """

--- a/tests/integration/test_tripletex_company.py
+++ b/tests/integration/test_tripletex_company.py
@@ -29,7 +29,7 @@ def generate_unique_name():
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_update_company_minimal(api):
+def test_update_company_minimal(api) -> None:
     """
     Test updating a company with minimal data.
 

--- a/tests/integration/test_tripletex_ledger_nested.py
+++ b/tests/integration/test_tripletex_ledger_nested.py
@@ -37,7 +37,7 @@ def get_dates():
     return date_from, date_to
 
 
-def test_api_ledger_group_registration(api):
+def test_api_ledger_group_registration(api) -> None:
     """
     Test that the LedgerGroup is properly registered in the API.
     """
@@ -51,7 +51,7 @@ def test_api_ledger_group_registration(api):
     assert hasattr(api.ledger.voucher, "historical")
 
 
-def test_list_ledgers(api):
+def test_list_ledgers(api) -> None:
     """
     Test listing ledgers from the Tripletex API using ResourceGroup.
     """
@@ -78,7 +78,7 @@ def test_list_ledgers(api):
             assert hasattr(ledger, "closing_balance")
 
 
-def test_read_ledger(api):
+def test_read_ledger(api) -> None:
     """
     Test reading a specific ledger from the Tripletex API using ResourceGroup.
     """
@@ -106,7 +106,7 @@ def test_read_ledger(api):
     assert hasattr(first_ledger, "closing_balance")
 
 
-def test_list_vouchers(api):
+def test_list_vouchers(api) -> None:
     """
     Test listing vouchers from the Tripletex API using nested ResourceGroup.
     """
@@ -131,7 +131,7 @@ def test_list_vouchers(api):
             assert hasattr(voucher, "description")
 
 
-def test_read_voucher(api):
+def test_read_voucher(api) -> None:
     """
     Test reading a specific voucher from the Tripletex API using nested ResourceGroup.
     """

--- a/tests/integration/test_tripletex_rate_limiting_live.py
+++ b/tests/integration/test_tripletex_rate_limiting_live.py
@@ -32,7 +32,7 @@ logging.getLogger("crudclient.ratelimit").setLevel(logging.DEBUG)
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_tripletex_rate_limiting_prevents_429():
+def test_tripletex_rate_limiting_prevents_429() -> None:
     """
     Test that rate limiter prevents 429 errors under real rate limit conditions.
 
@@ -167,7 +167,7 @@ def test_tripletex_rate_limiting_prevents_429():
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_rate_limiter_delay_tracking():
+def test_rate_limiter_delay_tracking() -> None:
     """Test that the rate limiter delay tracking mechanism works correctly."""
 
     print("\n=== Testing rate limiter delay tracking ===")

--- a/tests/integration/test_tripletex_suppliers.py
+++ b/tests/integration/test_tripletex_suppliers.py
@@ -7,7 +7,7 @@ from .tripletex_resources.models.supplier import Supplier
 
 
 @pytest.mark.no_parallel
-def test_list_suppliers(api):
+def test_list_suppliers(api) -> None:
     """
     Test listing suppliers.
     """
@@ -28,7 +28,7 @@ def test_list_suppliers(api):
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_create_update_destroy_supplier(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_create_update_destroy_supplier(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker) -> None:
     """
     Test creating, updating, and destroying a supplier.
     Uses fixtures for reliable cleanup and unique naming.
@@ -95,7 +95,7 @@ def test_create_update_destroy_supplier(api, unique_supplier_name, find_unused_s
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_supplier_number_uniqueness(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_supplier_number_uniqueness(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker) -> None:
     """
     Test supplier number handling - either enforces uniqueness or allows duplicates.
     This test adapts to the API's behavior.
@@ -144,7 +144,7 @@ def test_supplier_number_uniqueness(api, unique_supplier_name, find_unused_suppl
     reason="Skip test since unstable in CI environment",
 )
 @pytest.mark.no_parallel
-def test_multiple_suppliers_cleanup(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker):
+def test_multiple_suppliers_cleanup(api, unique_supplier_name, find_unused_supplier_number, supplier_tracker) -> None:
     """
     Test creating multiple suppliers and ensuring they're all cleaned up.
     This tests the robustness of our cleanup mechanism.

--- a/tests/unit/auth/test_apikey_auth_failures.py
+++ b/tests/unit/auth/test_apikey_auth_failures.py
@@ -10,7 +10,7 @@ import requests
 from crudclient.exceptions import AuthenticationError
 
 
-def test_apikey_header_auth_failure(apikey_header_client, mock_request):
+def test_apikey_header_auth_failure(apikey_header_client, mock_request) -> None:
     """Test handling of API Key Header Authentication failures."""
     # Arrange
     url = f"{apikey_header_client.base_url}/items"
@@ -32,7 +32,7 @@ def test_apikey_header_auth_failure(apikey_header_client, mock_request):
     assert "api_key" not in request.url
 
 
-def test_apikey_param_auth_failure(apikey_param_client, mock_request):
+def test_apikey_param_auth_failure(apikey_param_client, mock_request) -> None:
     """Test handling of API Key Param Authentication failures."""
     # Arrange
     endpoint = "/items"

--- a/tests/unit/auth/test_auth_failures.py
+++ b/tests/unit/auth/test_auth_failures.py
@@ -15,7 +15,7 @@ from crudclient.config import ClientConfig
 class TestAuthFailures:
     """Tests for general authentication failure handling."""
 
-    def test_auth_setup_failure(self, mock_request, mocker, bearer_auth_config: ClientConfig):
+    def test_auth_setup_failure(self, mock_request, mocker, bearer_auth_config: ClientConfig) -> None:
         """Test handling of authentication setup failures."""
         # Arrange
         # Create a bearer auth mock with a failing callback
@@ -37,7 +37,7 @@ class TestAuthFailures:
         # Check that the exception contains the error details
         assert "Auth setup failed" in str(excinfo.value)
 
-    def test_auth_param_setup_failure(self, mock_request, create_mock_client_config):
+    def test_auth_param_setup_failure(self, mock_request, create_mock_client_config) -> None:
         """
         Test that exceptions during auth parameter setup are propagated.
 

--- a/tests/unit/auth/test_auth_verification_helpers.py
+++ b/tests/unit/auth/test_auth_verification_helpers.py
@@ -5,7 +5,7 @@ from apiconfig.exceptions.auth import AuthenticationError
 class TestAuthVerificationHelpers:
     """Tests for authentication verification helpers."""
 
-    def test_verify_basic_auth_header(self, basic_auth_client, mock_auth_verification):
+    def test_verify_basic_auth_header(self, basic_auth_client, mock_auth_verification) -> None:
         """Test verification of Basic Auth headers."""
         # Arrange
         auth_strategy = basic_auth_client.config.auth_strategy
@@ -18,7 +18,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_basic_auth_header("NotBasic xyz")
 
-    def test_verify_bearer_auth_header(self, bearer_auth_client, mock_auth_verification):
+    def test_verify_bearer_auth_header(self, bearer_auth_client, mock_auth_verification) -> None:
         """Test verification of Bearer Auth headers."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -31,7 +31,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_bearer_auth_header("NotBearer xyz")
 
-    def test_assert_auth_header_format(self, bearer_auth_client, mock_auth_verification):
+    def test_assert_auth_header_format(self, bearer_auth_client, mock_auth_verification) -> None:
         """Test assertion of auth header format."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -44,7 +44,7 @@ class TestAuthVerificationHelpers:
         with pytest.raises(AuthenticationError):
             mock_auth_verification.verify_auth_header_format({"Authorization": "Invalid format"}, "bearer")
 
-    def test_assert_token_usage(self, bearer_auth_client, mock_auth_verification):
+    def test_assert_token_usage(self, bearer_auth_client, mock_auth_verification) -> None:
         """Test assertion of token usage."""
         # Arrange
         auth_strategy = bearer_auth_client.config.auth_strategy
@@ -57,7 +57,7 @@ class TestAuthVerificationHelpers:
         # call it separately without expecting it to compare values.
         # mock_auth_verification.assert_token_usage(token) # Example: Check JWT validity if needed
 
-    def test_assert_refresh_behavior(self, mock_auth_verification):
+    def test_assert_refresh_behavior(self, mock_auth_verification) -> None:
         """Test assertion of token refresh behavior."""
         # Arrange
         old_headers = {"Authorization": "Bearer old_token"}

--- a/tests/unit/auth/test_basic_auth_failures.py
+++ b/tests/unit/auth/test_basic_auth_failures.py
@@ -10,7 +10,7 @@ import requests
 from crudclient.exceptions import AuthenticationError
 
 
-def test_basic_auth_failure(basic_auth_client, mock_request):
+def test_basic_auth_failure(basic_auth_client, mock_request) -> None:
     """Test handling of Basic Authentication failures."""
     url = f"{basic_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid credentials"})

--- a/tests/unit/auth/test_bearer_auth_failures.py
+++ b/tests/unit/auth/test_bearer_auth_failures.py
@@ -11,7 +11,7 @@ import requests
 from crudclient.exceptions import AuthenticationError, ForbiddenError
 
 
-def test_bearer_auth_failure(bearer_auth_client, mock_request):
+def test_bearer_auth_failure(bearer_auth_client, mock_request) -> None:
     """Test handling of Bearer Authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -30,7 +30,7 @@ def test_bearer_auth_failure(bearer_auth_client, mock_request):
     assert request.headers["Authorization"] == "Bearer valid_token"
 
 
-def test_token_refresh_on_401(refreshable_token_client, mock_request):
+def test_token_refresh_on_401(refreshable_token_client, mock_request) -> None:
     """Test token refresh on 401 Unauthorized responses."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Token expired"})
@@ -51,7 +51,7 @@ def test_token_refresh_on_401(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Token expired"
 
 
-def test_token_refresh_on_403(refreshable_token_client, mock_request):
+def test_token_refresh_on_403(refreshable_token_client, mock_request) -> None:
     """Test token refresh on 403 Forbidden responses."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=403, json={"error": "Forbidden", "message": "Insufficient permissions"})
@@ -66,7 +66,7 @@ def test_token_refresh_on_403(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Insufficient permissions"
 
 
-def test_token_refresh_failure(refreshable_token_client, mock_request):
+def test_token_refresh_failure(refreshable_token_client, mock_request) -> None:
     """Test handling of token refresh failures."""
     url = f"{refreshable_token_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Token expired"})
@@ -85,7 +85,7 @@ def test_token_refresh_failure(refreshable_token_client, mock_request):
     assert response.json()["message"] == "Token expired"
 
 
-def test_retry_after_auth_failure(bearer_auth_client, mock_request):
+def test_retry_after_auth_failure(bearer_auth_client, mock_request) -> None:
     """Test retry behavior after authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -100,7 +100,7 @@ def test_retry_after_auth_failure(bearer_auth_client, mock_request):
     assert response.json()["message"] == "Invalid token"
 
 
-def test_auth_failure_with_retry_disabled(bearer_auth_client, mock_request):
+def test_auth_failure_with_retry_disabled(bearer_auth_client, mock_request) -> None:
     """Test handling of authentication failures with retry disabled."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})
@@ -115,7 +115,7 @@ def test_auth_failure_with_retry_disabled(bearer_auth_client, mock_request):
     assert response.json()["message"] == "Invalid token"
 
 
-def test_auth_header_overriding(bearer_auth_client, mock_request):
+def test_auth_header_overriding(bearer_auth_client, mock_request) -> None:
     """Test that authentication headers can be overridden."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, json={"data": "success"})
@@ -131,7 +131,7 @@ def test_auth_header_overriding(bearer_auth_client, mock_request):
     bearer_auth_client.http_client.session_manager.session.headers = original_headers
 
 
-def test_auth_header_merging(bearer_auth_client, mock_request):
+def test_auth_header_merging(bearer_auth_client, mock_request) -> None:
     """Test that authentication headers are merged with custom headers."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, json={"data": "success"})
@@ -148,7 +148,7 @@ def test_auth_header_merging(bearer_auth_client, mock_request):
     bearer_auth_client.http_client.session_manager.session.headers = original_headers
 
 
-def test_multiple_auth_failures(bearer_auth_client, mock_request):
+def test_multiple_auth_failures(bearer_auth_client, mock_request) -> None:
     """Test handling of multiple authentication failures."""
     url = f"{bearer_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid token"})

--- a/tests/unit/auth/test_create_auth_strategy.py
+++ b/tests/unit/auth/test_create_auth_strategy.py
@@ -33,7 +33,7 @@ class TestCreateAuthStrategy:
         token: Optional[Union[str, Tuple[str, str]]],
         expected_class: type,
         expected_attrs: Dict[str, str],
-    ):
+    ) -> None:
         """
         GIVEN an auth type string and a token/credential
         WHEN create_auth_strategy is called
@@ -52,7 +52,7 @@ class TestCreateAuthStrategy:
             for attr, value in expected_attrs.items():
                 assert getattr(auth, attr) == value
 
-    def test_create_basic_auth_invalid_token_type(self):
+    def test_create_basic_auth_invalid_token_type(self) -> None:
         """
         GIVEN the auth type 'basic' and an invalid token type (int)
         WHEN create_auth_strategy is called
@@ -62,7 +62,7 @@ class TestCreateAuthStrategy:
         with pytest.raises(TypeError, match="Basic auth token must be a string or tuple"):
             create_auth_strategy("basic", 123)  # type: ignore[arg-type]
 
-    def test_create_basic_auth_string_token_raises_error(self):
+    def test_create_basic_auth_string_token_raises_error(self) -> None:
         """
         GIVEN the auth type 'basic' and a string token (username only)
         WHEN create_auth_strategy is called
@@ -78,7 +78,7 @@ class TestCreateAuthStrategy:
     # as they require more complex configuration (header/param names or callbacks).
     # This is expected behavior. We test that they fall back to BearerAuth if a token is given.
 
-    def test_create_apikey_falls_back_to_bearer(self):
+    def test_create_apikey_falls_back_to_bearer(self) -> None:
         """
         GIVEN the auth type 'apikey' and a token string
         WHEN create_auth_strategy is called
@@ -95,7 +95,7 @@ class TestCreateAuthStrategy:
         assert isinstance(auth, BearerAuth)
         assert auth.access_token == token
 
-    def test_create_custom_falls_back_to_bearer(self):
+    def test_create_custom_falls_back_to_bearer(self) -> None:
         """
         GIVEN the auth type 'custom' and a token string
         WHEN create_auth_strategy is called

--- a/tests/unit/auth/test_custom_auth_failures.py
+++ b/tests/unit/auth/test_custom_auth_failures.py
@@ -11,7 +11,7 @@ from crudclient.config import ClientConfig
 from crudclient.exceptions import AuthenticationError
 
 
-def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test handling of custom authentication failures during setup."""
 
     def header_callback():
@@ -29,7 +29,7 @@ def test_custom_auth_failure(mock_request, basic_auth_config: ClientConfig):
     assert "Failed to generate custom header" in str(excinfo.value.__cause__)
 
 
-def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test that exceptions from param_callback are propagated."""
 
     def failing_param_callback() -> dict:
@@ -43,7 +43,7 @@ def test_custom_auth_param_callback_failure(mock_request, basic_auth_config: Cli
         client.get("/some/path")
 
 
-def test_custom_auth_api_failure(mock_request, basic_auth_config: ClientConfig):
+def test_custom_auth_api_failure(mock_request, basic_auth_config: ClientConfig) -> None:
     """Test handling of API returning 401/403 with CustomAuth."""
 
     def get_headers():

--- a/tests/unit/client/auth_examples/test_api_key_auth.py
+++ b/tests/unit/client/auth_examples/test_api_key_auth.py
@@ -15,7 +15,7 @@ from .common import create_mock_client
 class TestApiKeyAuthExamples:
     """Examples of using API Key Authentication mocks."""
 
-    def test_api_key_header_auth_success_scenario(self):
+    def test_api_key_header_auth_success_scenario(self) -> None:
         """Example of testing a successful API Key header auth scenario."""
         # Create a mock client with API Key header auth
         client = create_mock_client(auth_type="apikey", auth_config={"api_key": "valid_api_key", "header_name": "X-API-Key"})
@@ -37,7 +37,7 @@ class TestApiKeyAuthExamples:
         assert "X-API-Key" in request.kwargs["headers"]
         assert request.kwargs["headers"]["X-API-Key"] == "valid_api_key"
 
-    def test_api_key_param_auth_success_scenario(self):
+    def test_api_key_param_auth_success_scenario(self) -> None:
         """Example of testing a successful API Key param auth scenario."""
         # Create a mock client with API Key param auth
         client = create_mock_client(auth_type="apikey", auth_config={"api_key": "valid_api_key", "param_name": "api_key"})
@@ -60,7 +60,7 @@ class TestApiKeyAuthExamples:
         assert "api_key" in request.kwargs["params"]
         assert request.kwargs["params"]["api_key"] == "valid_api_key"
 
-    def test_api_key_auth_failure_scenario(self):
+    def test_api_key_auth_failure_scenario(self) -> None:
         """Example of testing an API Key auth failure scenario."""
         # Create a mock client with API Key auth configured to fail
         client = create_mock_client(

--- a/tests/unit/client/auth_examples/test_basic_auth.py
+++ b/tests/unit/client/auth_examples/test_basic_auth.py
@@ -16,7 +16,7 @@ from .common import create_mock_client
 class TestBasicAuthExamples:
     """Examples of using Basic Authentication mocks."""
 
-    def test_basic_auth_success_scenario(self):
+    def test_basic_auth_success_scenario(self) -> None:
         """Example of testing a successful Basic Auth scenario."""
         # Create a mock client with Basic Auth
         client = create_mock_client(auth_type="basic", auth_config={"username": "testuser", "password": "testpass"})
@@ -45,7 +45,7 @@ class TestBasicAuthExamples:
             expected_password="testpass",
         )
 
-    def test_basic_auth_failure_scenario(self):
+    def test_basic_auth_failure_scenario(self) -> None:
         """Example of testing a Basic Auth failure scenario."""
         # Create a mock client with Basic Auth configured to fail
         client = create_mock_client(

--- a/tests/unit/client/auth_examples/test_bearer_auth.py
+++ b/tests/unit/client/auth_examples/test_bearer_auth.py
@@ -15,7 +15,7 @@ from .common import create_mock_client
 class TestBearerAuthExamples:
     """Examples of using Bearer Authentication mocks."""
 
-    def test_bearer_auth_success_scenario(self):
+    def test_bearer_auth_success_scenario(self) -> None:
         """Example of testing a successful Bearer Auth scenario."""
         # Create a mock client with Bearer Auth
         client = create_mock_client(auth_type="bearer", auth_config={"token": "valid_token"})
@@ -38,7 +38,7 @@ class TestBearerAuthExamples:
         assert "Authorization" in request_call.kwargs["headers"]
         assert request_call.kwargs["headers"]["Authorization"] == "Bearer valid_token"
 
-    def test_bearer_auth_token_expiration_scenario(self):
+    def test_bearer_auth_token_expiration_scenario(self) -> None:
         """Example of testing a Bearer Auth token expiration scenario."""
         # Create a mock client with Bearer Auth configured with an expired token
         client = create_mock_client(auth_type="bearer", auth_config={"token": "expired_token", "token_expired": True})
@@ -56,7 +56,7 @@ class TestBearerAuthExamples:
         assert "401" in str(excinfo.value) or "Unauthorized" in str(excinfo.value)
         assert "Token expired" in str(excinfo.value)
 
-    def test_bearer_auth_token_refresh_scenario(self):
+    def test_bearer_auth_token_refresh_scenario(self) -> None:
         """Example of testing a Bearer Auth token refresh scenario."""
         # Create a mock client with Bearer Auth configured. The initial token value
         # doesn't matter much as the first request will be intercepted by the 401 pattern.

--- a/tests/unit/client/auth_examples/test_custom_auth.py
+++ b/tests/unit/client/auth_examples/test_custom_auth.py
@@ -16,7 +16,7 @@ from .common import create_mock_client
 class TestCustomAuthExamples:
     """Examples of using Custom Authentication mocks."""
 
-    def test_custom_auth_success_scenario(self):
+    def test_custom_auth_success_scenario(self) -> None:
         """Example of testing a successful Custom Auth scenario."""
 
         # Define custom auth callbacks
@@ -50,7 +50,7 @@ class TestCustomAuthExamples:
         # Assuming 'path' contains the full URL or path with params
         assert request.kwargs["params"].get("tenant") == "test_tenant"
 
-    def test_custom_auth_failure_scenario(self):
+    def test_custom_auth_failure_scenario(self) -> None:
         """Example of testing a Custom Auth failure scenario."""
 
         # Define a custom auth callback that will fail

--- a/tests/unit/client/auth_examples/test_mfa_auth.py
+++ b/tests/unit/client/auth_examples/test_mfa_auth.py
@@ -19,7 +19,7 @@ from .common import create_mock_client
 class TestMultiFactorAuthExamples:
     """Examples of using Multi-Factor Authentication mocks."""
 
-    def test_mfa_required_scenario(self):
+    def test_mfa_required_scenario(self) -> None:
         """Example of testing an MFA required scenario."""
         client = create_mock_client(auth_type="bearer", auth_config={"token": "valid_token", "mfa_required": True, "mfa_verified": False})
 
@@ -42,7 +42,7 @@ class TestMultiFactorAuthExamples:
         assert "Authorization" in request_call.kwargs["headers"]
         assert request_call.kwargs["headers"]["Authorization"] == "Bearer valid_token"
 
-    def test_mfa_verification_success_scenario(self):
+    def test_mfa_verification_success_scenario(self) -> None:
         """
         Tests the scenario where an initial request requires MFA,
         the MFA code is provided via the auth handler, and the subsequent

--- a/tests/unit/client/test_client_auth.py
+++ b/tests/unit/client/test_client_auth.py
@@ -7,7 +7,7 @@ from crudclient.config import ClientConfig
 
 class TestClientAuth:
 
-    def test_client_accepts_dict_config(self):
+    def test_client_accepts_dict_config(self) -> None:
         # Arrange
         config_dict = {
             "hostname": "https://example.com",
@@ -23,7 +23,7 @@ class TestClientAuth:
         assert client.config.version == "v1"
         assert client.session.headers["X-Test"] == "1"
 
-    def test_client_basic_auth_sets_session_headers(self, basic_auth_config: ClientConfig):
+    def test_client_basic_auth_sets_session_headers(self, basic_auth_config: ClientConfig) -> None:
         # Arrange
         config = basic_auth_config
 
@@ -34,7 +34,7 @@ class TestClientAuth:
         # Just check that the Authorization header exists
         assert "Authorization" in client.session.headers
 
-    def test_client_custom_auth_applies_headers(self, custom_auth_config: ClientConfig):
+    def test_client_custom_auth_applies_headers(self, custom_auth_config: ClientConfig) -> None:
         # Arrange
         config = custom_auth_config
 
@@ -44,7 +44,7 @@ class TestClientAuth:
         # Assert
         assert client.session.headers["X-Auth"] == "yes"
 
-    def test_client_bearer_token_auth_sets_session_headers(self):
+    def test_client_bearer_token_auth_sets_session_headers(self) -> None:
         """Test Client initialization with BearerTokenAuth sets the correct header."""
         # Arrange
         token = "my-secret-token"

--- a/tests/unit/client/test_client_initialization.py
+++ b/tests/unit/client/test_client_initialization.py
@@ -7,7 +7,7 @@ from crudclient.exceptions import ConfigurationError
 
 class TestClientInitialization:
 
-    def test_client_init_invalid_config_type_raises_typeerror(self):
+    def test_client_init_invalid_config_type_raises_typeerror(self) -> None:
         """Test that initializing Client with an invalid config type raises TypeError."""
         # Arrange
         invalid_config = 12345  # Not a ClientConfig or dict
@@ -20,7 +20,7 @@ class TestClientInitialization:
         assert "expected ClientConfig or dict" in str(excinfo.value)
         assert "got int" in str(excinfo.value)
 
-    def test_client_init_with_valid_clientconfig(self, valid_config):
+    def test_client_init_with_valid_clientconfig(self, valid_config) -> None:
         """Test successful initialization with a ClientConfig object."""
         # Arrange (valid_config fixture from conftest)
 
@@ -33,7 +33,7 @@ class TestClientInitialization:
         assert client.base_url == valid_config.base_url
         assert client.http_client is not None
 
-    def test_client_init_with_valid_dict(self):
+    def test_client_init_with_valid_dict(self) -> None:
         """Test successful initialization with a valid dictionary."""
         # Arrange
         config_dict = {

--- a/tests/unit/client/test_mock_client_examples.py
+++ b/tests/unit/client/test_mock_client_examples.py
@@ -13,7 +13,7 @@ from crudclient.testing.response_builder.pagination import (
 class TestMockClientExamples:
     """Examples of using the enhanced mock client for testing."""
 
-    def test_basic_response_pattern(self, mock_client: MockClient):
+    def test_basic_response_pattern(self, mock_client: MockClient) -> None:
         """Test basic response pattern matching."""
         # Configure the mock client with a response pattern
         mock_client.with_response_pattern(method="GET", path_pattern=r"/users/\d+", data={"id": 123, "name": "Test User"})
@@ -24,7 +24,7 @@ class TestMockClientExamples:
         # Verify the response
         assert response.json() == {"id": 123, "name": "Test User"}
 
-    def test_multiple_response_patterns(self, mock_client: MockClient):
+    def test_multiple_response_patterns(self, mock_client: MockClient) -> None:
         """Test multiple response patterns with different HTTP methods."""
         # Configure the mock client with multiple response patterns
         mock_client.with_response_pattern(method="GET", path_pattern=r"/users$", data={"users": [{"id": 1}, {"id": 2}]})
@@ -43,7 +43,7 @@ class TestMockClientExamples:
         assert create_response.json() == {"id": 3, "created": True}  # Note: Python boolean True
         assert user_one_response.json() == {"id": 1, "name": "User One"}
 
-    def test_parameter_matching(self, mock_client: MockClient):
+    def test_parameter_matching(self, mock_client: MockClient) -> None:
         """Test matching requests based on query parameters."""
         # Configure the mock client with parameter matching
         mock_client.with_response_pattern(
@@ -72,7 +72,7 @@ class TestMockClientExamples:
         # Since param matching isn't implemented, both requests get the first matching pattern's data.
         assert other_response.json() == {"results": ["test result"]}
 
-    def test_network_conditions(self, mock_client: MockClient):
+    def test_network_conditions(self, mock_client: MockClient) -> None:
         """Test simulating network conditions."""
         # Configure the mock client with network conditions
         mock_client.with_network_condition(
@@ -91,7 +91,7 @@ class TestMockClientExamples:
             # We expect some requests to fail with network errors
             assert "Simulated network error" in str(e)
 
-    def test_rate_limiting(self, mock_client: MockClient):
+    def test_rate_limiting(self, mock_client: MockClient) -> None:
         """Test simulating rate limiting."""
         # Configure the mock client with rate limiting
         mock_client.with_rate_limiter(limit=2, window_seconds=60)
@@ -114,7 +114,7 @@ class TestMockClientExamples:
         assert response3.status_code == 200
         # Or: assert "Rate limit exceeded" in response3.text # Check response body text
 
-    def test_request_verification(self, mock_client: MockClient):
+    def test_request_verification(self, mock_client: MockClient) -> None:
         """Test request verification helpers."""
         # Configure the mock client
         mock_client.with_response_pattern(method="GET", path_pattern=r"/users$", data={"users": []})
@@ -143,7 +143,7 @@ class TestMockClientExamples:
         assert len(get_calls) > 0
         assert get_calls[0].kwargs.get("params", {}).get("page") == "1"
 
-    def test_pagination_helper(self, mock_client: MockClient, create_user_data):
+    def test_pagination_helper(self, mock_client: MockClient, create_user_data) -> None:
         """Test pagination helper."""
         # Create test data
         users = [create_user_data(id=i) for i in range(1, 26)]

--- a/tests/unit/crud/test_create_operations.py
+++ b/tests/unit/crud/test_create_operations.py
@@ -28,7 +28,7 @@ SAMPLE_MODEL = BaseTestModel(**SAMPLE_PAYLOAD)
 # === Create Operation Tests ===
 
 
-def test_create_operation_success_with_model(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_success_with_model(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a model instance
     WHEN the create operation is called with the model
@@ -47,7 +47,7 @@ def test_create_operation_success_with_model(base_test_crud: BaseTestCrud, mock_
     assert isinstance(result, BaseTestModel)
 
 
-def test_create_operation_success_with_dict(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_success_with_dict(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a dictionary
     WHEN the create operation is called with the dictionary
@@ -65,7 +65,7 @@ def test_create_operation_success_with_dict(base_test_crud: BaseTestCrud, mock_c
     assert result == SAMPLE_MODEL
 
 
-def test_create_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a parent ID
     WHEN the create operation is called with a model and parent ID
@@ -82,7 +82,7 @@ def test_create_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_clie
     assert result == SAMPLE_MODEL
 
 
-def test_create_operation_validation_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_validation_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and invalid data (non-integer ID)
     WHEN the create operation is called with the invalid data
@@ -103,7 +103,7 @@ def test_create_operation_validation_error(base_test_crud: BaseTestCrud, mock_cl
     assert excinfo.value.data == invalid_data
 
 
-def test_create_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning invalid response data
     WHEN the create operation is called
@@ -122,7 +122,7 @@ def test_create_operation_model_conversion_error(base_test_crud: BaseTestCrud, m
     assert excinfo.value.data == {"unexpected": "field"}
 
 
-def test_create_operation_action_not_allowed(base_test_crud: BaseTestCrud):
+def test_create_operation_action_not_allowed(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance with 'create' action not in allowed_actions
     WHEN the create operation is called
@@ -136,7 +136,7 @@ def test_create_operation_action_not_allowed(base_test_crud: BaseTestCrud):
     base_test_crud.allowed_actions = original_actions  # Restore
 
 
-def test_create_operation_with_params(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_create_operation_with_params(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and query parameters
     WHEN the create operation is called with params

--- a/tests/unit/crud/test_custom_action_fix.py
+++ b/tests/unit/crud/test_custom_action_fix.py
@@ -11,7 +11,7 @@ from .conftest import BaseTestCrud
 TEST_DATA = {"param": "value"}
 
 
-def test_custom_action_post_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_post_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with POST method and data
@@ -27,7 +27,7 @@ def test_custom_action_post_with_data(base_test_crud: BaseTestCrud, mock_client:
     assert result is not None
 
 
-def test_custom_action_put_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_put_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with PUT method and data
@@ -43,7 +43,7 @@ def test_custom_action_put_with_data(base_test_crud: BaseTestCrud, mock_client: 
     assert result is not None
 
 
-def test_custom_action_patch_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_patch_with_data(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with PATCH method and data
@@ -59,7 +59,7 @@ def test_custom_action_patch_with_data(base_test_crud: BaseTestCrud, mock_client
     assert result is not None
 
 
-def test_custom_action_with_files(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_with_files(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with files parameter
@@ -76,7 +76,7 @@ def test_custom_action_with_files(base_test_crud: BaseTestCrud, mock_client: Mag
     assert result is not None
 
 
-def test_custom_action_with_content_type(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_with_content_type(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with content_type parameter

--- a/tests/unit/crud/test_custom_actions.py
+++ b/tests/unit/crud/test_custom_actions.py
@@ -26,7 +26,7 @@ SAMPLE_MODEL_LIST = [BaseTestModel(**item) for item in SAMPLE_LIST_PAYLOAD]
 # === Custom Action Tests ===
 
 
-def test_custom_action_post_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_post_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with POST method and data
@@ -45,7 +45,7 @@ def test_custom_action_post_success(base_test_crud: BaseTestCrud, mock_client: M
     assert result == SAMPLE_MODEL
 
 
-def test_custom_action_get_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_get_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called with GET method and params
@@ -64,7 +64,7 @@ def test_custom_action_get_success(base_test_crud: BaseTestCrud, mock_client: Ma
     assert result == SAMPLE_LIST_PAYLOAD  # Check if it returns raw list as per implementation
 
 
-def test_custom_action_on_resource_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_on_resource_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN a custom action is called on a specific resource
@@ -86,7 +86,7 @@ def test_custom_action_on_resource_success(base_test_crud: BaseTestCrud, mock_cl
 
 
 # Use the nested_test_crud fixture which has a parent configured
-def test_custom_action_with_parent_id(nested_base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_with_parent_id(nested_base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a parent ID
     WHEN a custom action is called with a parent ID
@@ -108,7 +108,7 @@ def test_custom_action_with_parent_id(nested_base_test_crud: BaseTestCrud, mock_
     assert result == SAMPLE_MODEL
 
 
-def test_custom_action_invalid_method(base_test_crud: BaseTestCrud):
+def test_custom_action_invalid_method(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance
     WHEN a custom action is called with an invalid HTTP method
@@ -119,7 +119,7 @@ def test_custom_action_invalid_method(base_test_crud: BaseTestCrud):
         base_test_crud.custom_action(action="test", method="invalid")
 
 
-def test_custom_action_type_error(base_test_crud: BaseTestCrud):
+def test_custom_action_type_error(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance
     WHEN a custom action is called with invalid parameter types
@@ -134,7 +134,7 @@ def test_custom_action_type_error(base_test_crud: BaseTestCrud):
         base_test_crud.custom_action(action="test", parent_id=123)
 
 
-def test_custom_action_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_custom_action_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning invalid response data
     WHEN a custom action is called

--- a/tests/unit/crud/test_destroy_operations.py
+++ b/tests/unit/crud/test_destroy_operations.py
@@ -18,7 +18,7 @@ from .conftest import BaseTestCrud  # Import fixtures/classes from conftest
 # === Destroy Operation Tests ===
 
 
-def test_destroy_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_destroy_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN the destroy operation is called with a resource ID
@@ -32,7 +32,7 @@ def test_destroy_operation_success(base_test_crud: BaseTestCrud, mock_client: Ma
     Verifier.verify_called_once_with(mock_client, "delete", "test-resources/1")
 
 
-def test_destroy_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_destroy_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a parent ID
     WHEN the destroy operation is called with a resource ID and parent ID
@@ -47,7 +47,7 @@ def test_destroy_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_cli
     # Verifier.verify_called_once_with(mock_client, "delete", "parents/parent123/test-resources/1") # Example assertion
 
 
-def test_destroy_operation_action_not_allowed(base_test_crud: BaseTestCrud):
+def test_destroy_operation_action_not_allowed(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance with 'destroy' action not in allowed_actions
     WHEN the destroy operation is called

--- a/tests/unit/crud/test_error_handling.py
+++ b/tests/unit/crud/test_error_handling.py
@@ -32,7 +32,7 @@ SAMPLE_PAYLOAD = {"id": 1, "name": "Test Resource", "secret": "password123"}  # 
 SAMPLE_MODEL = BaseTestModel(**SAMPLE_PAYLOAD)
 
 
-def test_crud_operation_client_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_crud_operation_client_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client raising network errors
     WHEN CRUD operations are called
@@ -67,7 +67,7 @@ def test_crud_operation_client_error_4xx(
     status_code: int,
     expected_exception: Type[CrudClientError],
     error_payload: dict,
-):
+) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and various operation parameters
     WHEN operations that result in 4xx errors are called
@@ -147,7 +147,7 @@ def test_crud_operation_client_error_4xx(
         ("custom_action", {"action": "test-action", "method": "post"}),
     ],
 )
-def test_crud_operation_server_error_5xx(base_test_crud: BaseTestCrud, mock_client: MagicMock, operation_name: str, operation_args: dict):
+def test_crud_operation_server_error_5xx(base_test_crud: BaseTestCrud, mock_client: MagicMock, operation_name: str, operation_args: dict) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and various operation parameters
     WHEN operations that result in 5xx errors are called

--- a/tests/unit/crud/test_list_operations.py
+++ b/tests/unit/crud/test_list_operations.py
@@ -27,7 +27,7 @@ SAMPLE_MODEL_LIST = [BaseTestModel(**item) for item in SAMPLE_LIST_PAYLOAD]
 # === List Operation Tests ===
 
 
-def test_list_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_list_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning a list payload
     WHEN the list operation is called
@@ -42,7 +42,7 @@ def test_list_operation_success(base_test_crud: BaseTestCrud, mock_client: Magic
     assert all(isinstance(item, BaseTestModel) for item in result)
 
 
-def test_list_operation_with_params(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_list_operation_with_params(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN the list operation is called with filtering/pagination params
@@ -57,7 +57,7 @@ def test_list_operation_with_params(base_test_crud: BaseTestCrud, mock_client: M
     assert result == SAMPLE_MODEL_LIST
 
 
-def test_list_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_list_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client
     WHEN the list operation is called with a parent ID
@@ -72,7 +72,7 @@ def test_list_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client
     assert result == SAMPLE_MODEL_LIST
 
 
-def test_list_operation_empty(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_list_operation_empty(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning an empty list
     WHEN the list operation is called
@@ -86,7 +86,7 @@ def test_list_operation_empty(base_test_crud: BaseTestCrud, mock_client: MagicMo
     assert result == []
 
 
-def test_list_operation_action_not_allowed(base_test_crud: BaseTestCrud):
+def test_list_operation_action_not_allowed(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance with 'list' action not in allowed_actions
     WHEN the list operation is called
@@ -104,7 +104,7 @@ def test_list_operation_action_not_allowed(base_test_crud: BaseTestCrud):
 # Adding a basic one for completeness, assuming conversion happens on list items.
 
 
-def test_list_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_list_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning invalid list item data
     WHEN the list operation is called

--- a/tests/unit/crud/test_read_operations.py
+++ b/tests/unit/crud/test_read_operations.py
@@ -25,7 +25,7 @@ SAMPLE_MODEL = BaseTestModel(**SAMPLE_PAYLOAD)
 # === Read Operation Tests ===
 
 
-def test_read_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_read_operation_success(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning a resource payload
     WHEN the read operation is called with a resource ID
@@ -40,7 +40,7 @@ def test_read_operation_success(base_test_crud: BaseTestCrud, mock_client: Magic
     assert isinstance(result, BaseTestModel)
 
 
-def test_read_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_read_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and a parent ID
     WHEN the read operation is called with a resource ID and parent ID
@@ -55,7 +55,7 @@ def test_read_operation_with_parent_id(base_test_crud: BaseTestCrud, mock_client
     assert result == SAMPLE_MODEL
 
 
-def test_read_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_read_operation_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client returning invalid response data
     WHEN the read operation is called
@@ -74,7 +74,7 @@ def test_read_operation_model_conversion_error(base_test_crud: BaseTestCrud, moc
     assert excinfo.value.data == {"unexpected": "field"}
 
 
-def test_read_operation_action_not_allowed(base_test_crud: BaseTestCrud):
+def test_read_operation_action_not_allowed(base_test_crud: BaseTestCrud) -> None:
     """
     GIVEN a TestCrud instance with 'read' action not in allowed_actions
     WHEN the read operation is called

--- a/tests/unit/crud/test_validation_logging.py
+++ b/tests/unit/crud/test_validation_logging.py
@@ -40,7 +40,7 @@ class TestCrudRequestValidationLogging:
         caplog,
         operation_name: str,
         operation_args: dict,
-    ):
+    ) -> None:
         """
         GIVEN a CRUD operation (create, update, partial_update)
         WHEN input data fails Pydantic validation before the API call
@@ -119,7 +119,7 @@ class TestCrudResponseValidationLogging:
         operation_name: str,
         operation_args: dict,
         client_method_name: str,
-    ):
+    ) -> None:
         """
         GIVEN a CRUD operation returning a single item
         WHEN the API response data fails Pydantic validation
@@ -173,7 +173,7 @@ class TestCrudResponseValidationLogging:
         base_test_crud: BaseTestCrud,
         mock_client: MagicMock,
         caplog,
-    ):
+    ) -> None:
         """
         GIVEN a 'list' operation
         WHEN the API response list contains data that fails Pydantic validation

--- a/tests/unit/http/errors/test_client_errors.py
+++ b/tests/unit/http/errors/test_client_errors.py
@@ -22,7 +22,7 @@ from crudclient.exceptions import (
 class TestHttpClientClientErrors:
     """Tests for handling client errors in the HTTP client."""
 
-    def test_400_error(self, http_client, mock_request):
+    def test_400_error(self, http_client, mock_request) -> None:
         """
         Test handling of 400 Bad Request.
 
@@ -41,7 +41,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid parameters"
 
-    def test_401_error(self, http_client, mock_request):
+    def test_401_error(self, http_client, mock_request) -> None:
         """
         Test handling of 401 Unauthorized.
 
@@ -60,7 +60,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Authentication required"
 
-    def test_403_error(self, http_client, mock_request):
+    def test_403_error(self, http_client, mock_request) -> None:
         """
         Test handling of 403 Forbidden.
 
@@ -79,7 +79,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Insufficient permissions"
 
-    def test_404_error(self, http_client, mock_request):
+    def test_404_error(self, http_client, mock_request) -> None:
         """
         Test handling of 404 Not Found.
 
@@ -98,7 +98,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Resource not found"
 
-    def test_422_error(self, http_client, mock_request):
+    def test_422_error(self, http_client, mock_request) -> None:
         """
         Test handling of 422 Unprocessable Entity.
 
@@ -117,7 +117,7 @@ class TestHttpClientClientErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Validation failed"
 
-    def test_429_error(self, http_client, mock_request):
+    def test_429_error(self, http_client, mock_request) -> None:
         """
         Test handling of 429 Too Many Requests.
 

--- a/tests/unit/http/errors/test_malformed_responses.py
+++ b/tests/unit/http/errors/test_malformed_responses.py
@@ -15,7 +15,7 @@ from crudclient.exceptions import ResponseParsingError
 class TestHttpClientMalformedResponses:
     """Tests for handling malformed responses in the HTTP client."""
 
-    def test_malformed_json_response(self, http_client, mock_request):
+    def test_malformed_json_response(self, http_client, mock_request) -> None:
         """
         Test handling of malformed JSON responses.
 
@@ -34,7 +34,7 @@ class TestHttpClientMalformedResponses:
         assert isinstance(excinfo.value.original_exception, requests.exceptions.JSONDecodeError)
         assert "Expecting value" in str(excinfo.value.original_exception)
 
-    def test_empty_response(self, http_client, mock_request):
+    def test_empty_response(self, http_client, mock_request) -> None:
         """
         Test handling of empty responses.
 
@@ -49,7 +49,7 @@ class TestHttpClientMalformedResponses:
         response = http_client.get("/users")
         assert response is None or response == ""
 
-    def test_non_json_content_type(self, http_client, mock_request):
+    def test_non_json_content_type(self, http_client, mock_request) -> None:
         """
         Test handling of non-JSON content types.
 
@@ -64,7 +64,7 @@ class TestHttpClientMalformedResponses:
         response = http_client.get("/users")
         assert response == "<html>Not JSON</html>"
 
-    def test_unexpected_content_type(self, http_client, mock_request):
+    def test_unexpected_content_type(self, http_client, mock_request) -> None:
         """
         Test handling of unexpected content types.
 

--- a/tests/unit/http/errors/test_server_errors.py
+++ b/tests/unit/http/errors/test_server_errors.py
@@ -16,7 +16,7 @@ from crudclient.exceptions import APIError
 class TestHttpClientServerErrors:
     """Tests for handling server errors in the HTTP client."""
 
-    def test_500_error(self, http_client, mock_request):
+    def test_500_error(self, http_client, mock_request) -> None:
         """
         Test handling of 500 Internal Server Error.
 
@@ -35,7 +35,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Something went wrong"
 
-    def test_502_error(self, http_client, mock_request):
+    def test_502_error(self, http_client, mock_request) -> None:
         """
         Test handling of 502 Bad Gateway.
 
@@ -54,7 +54,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid response from upstream server"
 
-    def test_503_error(self, http_client, mock_request):
+    def test_503_error(self, http_client, mock_request) -> None:
         """
         Test handling of 503 Service Unavailable.
 
@@ -73,7 +73,7 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Server is overloaded"
 
-    def test_504_error(self, http_client, mock_request):
+    def test_504_error(self, http_client, mock_request) -> None:
         """
         Test handling of 504 Gateway Timeout.
 

--- a/tests/unit/http/test_http_logging_completion.py
+++ b/tests/unit/http/test_http_logging_completion.py
@@ -53,7 +53,7 @@ def test_log_request_completion_success(
     mock_logger: MagicMock,
     mock_response: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify successful request completion logging."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -75,7 +75,7 @@ def test_log_request_completion_failure_response(
     mock_logger: MagicMock,
     mock_response: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify failed request completion logging (with error response)."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -106,7 +106,7 @@ def test_log_request_completion_failure_exception(
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,  # Need request info for the log
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify failed request completion logging (with exception)."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]
@@ -128,7 +128,7 @@ def test_log_request_completion_no_outcome(
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
     patch_time: MagicMock,  # Explicitly request fixture
-):
+) -> None:
     """Verify request completion logging when outcome is None."""
     # patch_time provides start_time=100.0, end_time=100.555
     start_time = 100.0  # Matches patch_time.side_effect[0]

--- a/tests/unit/http/test_http_logging_error.py
+++ b/tests/unit/http/test_http_logging_error.py
@@ -54,7 +54,7 @@ def test_log_http_error_4xx(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,  # Response attached to exception
-):
+) -> None:
     """Verify HTTPError logging for 4xx status codes."""
     # Ensure response has the correct attributes for this test
     mock_response.status_code = 404
@@ -82,7 +82,7 @@ def test_log_http_error_5xx(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,
-):
+) -> None:
     """Verify HTTPError logging for 5xx status codes."""
     # Ensure response has the correct attributes for this test
     mock_response.status_code = 503
@@ -109,7 +109,7 @@ def test_log_http_error_5xx(
 def test_log_http_error_no_response(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
-):
+) -> None:
     """Verify HTTPError logging when the error has no response object."""
     request = MagicMock(spec=requests.PreparedRequest, method="PUT", url="https://example.com/update")
     error = requests.exceptions.HTTPError("Some connection issue", request=request, response=None)
@@ -124,7 +124,7 @@ def test_log_http_error_no_response(
 def test_log_http_error_no_request_or_response(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
-):
+) -> None:
     """Verify HTTPError logging when the error has no request or response."""
     error = requests.exceptions.HTTPError("Very early error")
     error.request = None  # Explicitly set to None

--- a/tests/unit/http/test_http_logging_request.py
+++ b/tests/unit/http/test_http_logging_request.py
@@ -41,7 +41,7 @@ def test_log_request_details_base(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify basic request details logging (method, URL, headers)."""
     method = mock_prepared_request.method
     url = mock_prepared_request.url
@@ -67,7 +67,7 @@ def test_log_request_details_no_params(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request details logging when no params are present."""
     method = mock_prepared_request.method
     url = mock_prepared_request.url
@@ -87,7 +87,7 @@ def test_log_request_details_with_body_enabled(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request body logging when log_request_body is True."""
     mock_client_config.log_request_body = True  # Enable body logging
     method = mock_prepared_request.method
@@ -116,7 +116,7 @@ def test_log_request_details_with_long_body_truncated(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify request body truncation."""
     mock_client_config.log_request_body = True
     method = mock_prepared_request.method
@@ -160,7 +160,7 @@ def test_log_request_details_with_data_kwarg(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_prepared_request: MagicMock,
-):
+) -> None:
     """Verify logging when 'data' kwarg is used instead of 'json'."""
     mock_client_config.log_request_body = True
     method = mock_prepared_request.method
@@ -187,7 +187,7 @@ def test_log_request_details_header_redaction(
     mock_client_config: MagicMock,  # Use config directly
     caplog: pytest.LogCaptureFixture,
     # mock_prepared_request: MagicMock, # Not needed as we define headers directly
-):
+) -> None:
     """Verify sensitive headers are redacted in logs using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_header_redaction")
@@ -236,7 +236,7 @@ def test_log_request_details_body_redaction_simple(
     # http_logger: HttpLifecycleLogger, # Remove fixture
     caplog: pytest.LogCaptureFixture,
     mock_client_config: MagicMock,  # Fixture from conftest.py
-):
+) -> None:
     """Verify simple sensitive keys in JSON body are redacted using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_body_redaction_simple")
@@ -289,7 +289,7 @@ def test_log_request_details_body_redaction_nested(
     # http_logger: HttpLifecycleLogger, # Remove fixture
     caplog: pytest.LogCaptureFixture,
     mock_client_config: MagicMock,  # Fixture from conftest.py
-):
+) -> None:
     """Verify nested sensitive keys in JSON body are redacted using caplog."""
     # Instantiate logger with a real logger for caplog
     test_logger = logging.getLogger("test_body_redaction_nested")

--- a/tests/unit/http/test_http_logging_response.py
+++ b/tests/unit/http/test_http_logging_response.py
@@ -68,7 +68,7 @@ def test_log_response_details_base(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,
-):
+) -> None:
     """Verify basic response details logging (status, headers)."""
     method = mock_response.request.method
     url = mock_response.request.url
@@ -88,7 +88,7 @@ def test_log_response_details_error_status(
     http_logger: HttpLifecycleLogger,
     mock_logger: MagicMock,
     mock_response: MagicMock,
-):
+) -> None:
     """Verify warning/error logging for non-2xx status codes."""
     method = mock_response.request.method
     url = mock_response.request.url
@@ -114,7 +114,7 @@ def test_log_response_details_with_body_enabled(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify response body logging when log_response_body is True."""
     mock_client_config.log_response_body = True  # Enable body logging
     method = mock_response.request.method
@@ -153,7 +153,7 @@ def test_log_response_details_with_long_body_truncated(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify response body truncation."""
     mock_client_config.log_response_body = True
     method = mock_response.request.method
@@ -205,7 +205,7 @@ def test_log_response_details_non_json_body(
     mock_logger: MagicMock,
     mock_client_config: MagicMock,  # Fixture from conftest.py
     mock_response: MagicMock,
-):
+) -> None:
     """Verify logging for non-JSON response bodies."""
     mock_client_config.log_response_body = True
     method = mock_response.request.method

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -25,7 +25,7 @@ from crudclient.http.utils import redact_json_body
 def test_log_response_body_redaction_simple(
     mock_client_config: MagicMock,  # Use the imported fixture type
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Verify simple sensitive keys in JSON response body are redacted."""
     mock_client_config.log_response_body = True  # Enable body logging
     caplog.set_level("DEBUG")
@@ -75,7 +75,7 @@ def test_log_response_body_redaction_simple(
 def test_log_response_body_redaction_nested_list(
     mock_client_config: MagicMock,  # Use the imported fixture type
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     """Verify sensitive keys in nested lists within response body are redacted."""
     mock_client_config.log_response_body = True  # Enable body logging
     caplog.set_level("DEBUG")
@@ -138,7 +138,7 @@ class SensitiveModel(BaseModel):
 # Removed defunct test_data_validation_error_log_redaction
 
 
-def test_data_validation_error_exception_redaction():
+def test_data_validation_error_exception_redaction() -> None:
     """Verify sensitive data is redacted in DataValidationError exception attributes."""
     invalid_data = {
         "user_id": "not-an-int",

--- a/tests/unit/testing/auth/test_factory.py
+++ b/tests/unit/testing/auth/test_factory.py
@@ -13,7 +13,7 @@ from crudclient.testing.auth.factory import (
 )
 
 
-def test_create_basic_auth_mock():
+def test_create_basic_auth_mock() -> None:
     """Verify creating a basic auth mock."""
     auth_mock = create_basic_auth_mock()
     assert isinstance(auth_mock, BasicAuthMock)
@@ -21,14 +21,14 @@ def test_create_basic_auth_mock():
     assert auth_mock.password == "pass"  # Check default value
 
 
-def test_create_bearer_auth_mock():
+def test_create_bearer_auth_mock() -> None:
     """Verify creating a bearer auth mock."""
     auth_mock = create_bearer_auth_mock()
     assert isinstance(auth_mock, BearerAuthMock)
     assert auth_mock.token == "valid_token"  # Check default value
 
 
-def test_create_api_key_auth_mock():
+def test_create_api_key_auth_mock() -> None:
     """Verify creating an API key auth mock."""
     auth_mock = create_api_key_auth_mock()
     assert isinstance(auth_mock, ApiKeyAuthMock)
@@ -36,14 +36,14 @@ def test_create_api_key_auth_mock():
     assert auth_mock.header_name == "X-API-Key"  # Check default value
 
 
-def test_create_custom_auth_mock():
+def test_create_custom_auth_mock() -> None:
     """Verify creating a custom auth mock."""
     auth_mock = create_custom_auth_mock()
     assert isinstance(auth_mock, CustomAuthMock)
     # Add more specific assertions if needed based on CustomAuthMock implementation
 
 
-def test_create_oauth_mock():
+def test_create_oauth_mock() -> None:
     """Verify creating an OAuth mock."""
     auth_mock = create_oauth_mock()
     assert isinstance(auth_mock, OAuthMock)

--- a/tests/unit/testing/auth/test_oauth_scope_validator.py
+++ b/tests/unit/testing/auth/test_oauth_scope_validator.py
@@ -3,7 +3,7 @@ import pytest
 from crudclient.testing.auth.oauth_scope_validator import OAuthScopeValidator
 
 
-def test_scope_validator_init():
+def test_scope_validator_init() -> None:
     """Test initial state of the scope validator."""
     validator = OAuthScopeValidator()
     # Check default available scopes (might change, so check a few known ones)
@@ -12,14 +12,14 @@ def test_scope_validator_init():
     assert validator.required_scopes == set()
 
 
-def test_set_available_scopes():
+def test_set_available_scopes() -> None:
     """Test setting available scopes, overwriting defaults."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["scope1", "scope2"])
     assert validator.available_scopes == {"scope1", "scope2"}
 
 
-def test_add_available_scope():
+def test_add_available_scope() -> None:
     """Test adding an available scope."""
     validator = OAuthScopeValidator()
     initial_scopes = validator.available_scopes.copy()
@@ -27,14 +27,14 @@ def test_add_available_scope():
     assert validator.available_scopes == initial_scopes.union({"new_scope"})
 
 
-def test_set_required_scopes():
+def test_set_required_scopes() -> None:
     """Test setting required scopes."""
     validator = OAuthScopeValidator()
     validator.set_required_scopes(["req1", "req2"])
     assert validator.required_scopes == {"req1", "req2"}
 
 
-def test_add_required_scope():
+def test_add_required_scope() -> None:
     """Test adding a required scope."""
     validator = OAuthScopeValidator()
     validator.add_required_scope("req1")
@@ -78,7 +78,7 @@ def test_add_required_scope():
         ([], ["read"], "", False),  # Required scope not available
     ],
 )
-def test_validate_scopes(available, required, provided, expected):
+def test_validate_scopes(available, required, provided, expected) -> None:
     validator = OAuthScopeValidator()
     if available is not None:
         validator.set_available_scopes(available)
@@ -88,7 +88,7 @@ def test_validate_scopes(available, required, provided, expected):
     assert validator.validate_scopes(provided) is expected
 
 
-def test_get_default_scopes_no_required():
+def test_get_default_scopes_no_required() -> None:
     """Test default scopes when none are required."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "profile", "email"])
@@ -96,7 +96,7 @@ def test_get_default_scopes_no_required():
     assert validator.get_default_scopes() == "read"
 
 
-def test_get_default_scopes_with_required():
+def test_get_default_scopes_with_required() -> None:
     """Test default scopes includes required scopes."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "admin", "profile"])
@@ -105,7 +105,7 @@ def test_get_default_scopes_with_required():
     assert validator.get_default_scopes() == "admin profile read"
 
 
-def test_get_default_scopes_required_not_available():
+def test_get_default_scopes_required_not_available() -> None:
     """Test default scopes when required scope isn't available (edge case)."""
     validator = OAuthScopeValidator()
     validator.set_available_scopes(["read", "write"])

--- a/tests/unit/testing/core/test_client_initialization.py
+++ b/tests/unit/testing/core/test_client_initialization.py
@@ -9,7 +9,7 @@ from tests.unit.helpers import translate_mock_calls_for_verifier
 class TestMockClientInitialization:
     """Tests for the initialization and configuration of MockClient."""
 
-    def test_init(self):
+    def test_init(self) -> None:
         """Test initialization of MockClient."""
         # Arrange
         http_client = MagicMock()
@@ -25,7 +25,7 @@ class TestMockClientInitialization:
         assert client.get_call_count() == 0
         assert client._auth_strategy is None
 
-    def test_configure_response(self):
+    def test_configure_response(self) -> None:
         """Test configure_response method."""
         # Arrange
         http_client = MagicMock()
@@ -53,7 +53,7 @@ class TestMockClientInitialization:
             error=None,
         )
 
-    def test_set_auth_strategy(self):
+    def test_set_auth_strategy(self) -> None:
         """Test set_auth_strategy method."""
         # Arrange
         http_client = MagicMock()
@@ -67,7 +67,7 @@ class TestMockClientInitialization:
         assert client._auth_strategy == auth_strategy
         assert client.config.auth_strategy == auth_strategy
 
-    def test_get_auth_strategy(self):
+    def test_get_auth_strategy(self) -> None:
         """Test get_auth_strategy method."""
         # Arrange
         http_client = MagicMock()


### PR DESCRIPTION
## Summary
- add missing `-> None` annotations to all test functions

## Testing
- `pre-commit run --files tests/integration/test_fiken.py tests/integration/test_tripletex.py tests/integration/test_tripletex_company.py tests/integration/test_tripletex_ledger_nested.py tests/integration/test_tripletex_rate_limiting_live.py tests/integration/test_tripletex_suppliers.py tests/unit/auth/test_apikey_auth_failures.py tests/unit/auth/test_auth_failures.py tests/unit/auth/test_auth_verification_helpers.py tests/unit/auth/test_basic_auth_failures.py tests/unit/auth/test_bearer_auth_failures.py tests/unit/auth/test_create_auth_strategy.py tests/unit/auth/test_custom_auth_failures.py tests/unit/client/auth_examples/test_api_key_auth.py tests/unit/client/auth_examples/test_basic_auth.py tests/unit/client/auth_examples/test_bearer_auth.py tests/unit/client/auth_examples/test_custom_auth.py tests/unit/client/auth_examples/test_mfa_auth.py tests/unit/client/test_client_auth.py tests/unit/client/test_client_initialization.py tests/unit/client/test_mock_client_examples.py tests/unit/crud/test_create_operations.py tests/unit/crud/test_custom_action_fix.py tests/unit/crud/test_custom_actions.py tests/unit/crud/test_destroy_operations.py tests/unit/crud/test_error_handling.py tests/unit/crud/test_list_operations.py tests/unit/crud/test_read_operations.py tests/unit/crud/test_validation_logging.py tests/unit/http/errors/test_client_errors.py tests/unit/http/errors/test_malformed_responses.py tests/unit/http/errors/test_server_errors.py tests/unit/http/test_http_logging_completion.py tests/unit/http/test_http_logging_error.py tests/unit/http/test_http_logging_request.py tests/unit/http/test_http_logging_response.py tests/unit/test_redaction.py tests/unit/testing/auth/test_factory.py tests/unit/testing/auth/test_oauth_scope_validator.py tests/unit/testing/core/test_client_initialization.py`
- `pytest -q` *(fails: crudclient.exceptions.NetworkError: connection error due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6865bfed88088332b2c1b2433ad2fa5d