### PR TITLE
Add return annotations in error handling tests

### DIFF
--- a/tests/unit/crud/test_error_handling.py
+++ b/tests/unit/crud/test_error_handling.py
@@ -32,7 +32,7 @@ SAMPLE_PAYLOAD = {"id": 1, "name": "Test Resource", "secret": "password123"}  # 
 SAMPLE_MODEL = BaseTestModel(**SAMPLE_PAYLOAD)
 
 
-def test_crud_operation_client_error(base_test_crud: BaseTestCrud, mock_client: MagicMock):
+def test_crud_operation_client_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:
     """
     GIVEN a TestCrud instance and a mocked client raising network errors
     WHEN CRUD operations are called
@@ -67,7 +67,7 @@ def test_crud_operation_client_error_4xx(
     status_code: int,
     expected_exception: Type[CrudClientError],
     error_payload: dict,
-):
+) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and various operation parameters
     WHEN operations that result in 4xx errors are called
@@ -147,7 +147,7 @@ def test_crud_operation_client_error_4xx(
         ("custom_action", {"action": "test-action", "method": "post"}),
     ],
 )
-def test_crud_operation_server_error_5xx(base_test_crud: BaseTestCrud, mock_client: MagicMock, operation_name: str, operation_args: dict):
+def test_crud_operation_server_error_5xx(base_test_crud: BaseTestCrud, mock_client: MagicMock, operation_name: str, operation_args: dict) -> None:
     """
     GIVEN a TestCrud instance, a mocked client, and various operation parameters
     WHEN operations that result in 5xx errors are called


### PR DESCRIPTION
## Summary
- add explicit `None` return annotations to tests in `tests/unit/crud/test_error_handling.py`

## Testing
- `pre-commit run --files tests/unit/crud/test_error_handling.py`

------
https://chatgpt.com/codex/tasks/task_e_68668c084b4c8332b3251043f11eb786