### PR TITLE
Add missing type hints for HTTP client server error tests

### DIFF
--- a/tests/unit/http/errors/test_server_errors.py
+++ b/tests/unit/http/errors/test_server_errors.py
@@ -9,14 +9,20 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
 from crudclient.exceptions import APIError
+from crudclient.http.client import HttpClient
 
 
 class TestHttpClientServerErrors:
     """Tests for handling server errors in the HTTP client."""
 
-    def test_500_error(self, http_client, mock_request):
+    def test_500_error(
+        self,
+        http_client: HttpClient,
+        mock_request: requests_mock.Mocker,
+    ) -> None:
         """
         Test handling of 500 Internal Server Error.
 
@@ -35,7 +41,11 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Something went wrong"
 
-    def test_502_error(self, http_client, mock_request):
+    def test_502_error(
+        self,
+        http_client: HttpClient,
+        mock_request: requests_mock.Mocker,
+    ) -> None:
         """
         Test handling of 502 Bad Gateway.
 
@@ -54,7 +64,11 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Invalid response from upstream server"
 
-    def test_503_error(self, http_client, mock_request):
+    def test_503_error(
+        self,
+        http_client: HttpClient,
+        mock_request: requests_mock.Mocker,
+    ) -> None:
         """
         Test handling of 503 Service Unavailable.
 
@@ -73,7 +87,11 @@ class TestHttpClientServerErrors:
         response = cast(requests.Response, excinfo.value.response)
         assert response.json()["message"] == "Server is overloaded"
 
-    def test_504_error(self, http_client, mock_request):
+    def test_504_error(
+        self,
+        http_client: HttpClient,
+        mock_request: requests_mock.Mocker,
+    ) -> None:
         """
         Test handling of 504 Gateway Timeout.
 


### PR DESCRIPTION
## Summary
- add `HttpClient` and `requests_mock` imports to `test_server_errors`
- type annotate server error test methods

## Testing
- `pre-commit run --files tests/unit/http/errors/test_server_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68668c0462f483328eccd505131094cf