### PR TITLE
Add type hints to API key auth failure tests

### DIFF
--- a/tests/unit/auth/test_apikey_auth_failures.py
+++ b/tests/unit/auth/test_apikey_auth_failures.py
@@ -6,11 +6,13 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
+from crudclient.client import Client
 from crudclient.exceptions import AuthenticationError
 
 
-def test_apikey_header_auth_failure(apikey_header_client, mock_request):
+def test_apikey_header_auth_failure(apikey_header_client: Client, mock_request: requests_mock.Mocker) -> None:
     """Test handling of API Key Header Authentication failures."""
     # Arrange
     url = f"{apikey_header_client.base_url}/items"
@@ -32,7 +34,7 @@ def test_apikey_header_auth_failure(apikey_header_client, mock_request):
     assert "api_key" not in request.url
 
 
-def test_apikey_param_auth_failure(apikey_param_client, mock_request):
+def test_apikey_param_auth_failure(apikey_param_client: Client, mock_request: requests_mock.Mocker) -> None:
     """Test handling of API Key Param Authentication failures."""
     # Arrange
     endpoint = "/items"


### PR DESCRIPTION
## Summary
- type hint parameters and returns for API key auth tests
- add imports for `requests_mock` and `Client`

## Testing
- `poetry run pre-commit run --files tests/unit/auth/test_apikey_auth_failures.py`
- `poetry run pytest tests/unit/auth/test_apikey_auth_failures.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68668beafc6483328d86b81ee3f273a2