### PR TITLE
Update tests with return type hints

### DIFF
--- a/tests/unit/client/auth_examples/test_basic_auth.py
+++ b/tests/unit/client/auth_examples/test_basic_auth.py
@@ -16,7 +16,7 @@ from .common import create_mock_client
 class TestBasicAuthExamples:
     """Examples of using Basic Authentication mocks."""
 
-    def test_basic_auth_success_scenario(self):
+    def test_basic_auth_success_scenario(self) -> None:
         """Example of testing a successful Basic Auth scenario."""
         # Create a mock client with Basic Auth
         client = create_mock_client(auth_type="basic", auth_config={"username": "testuser", "password": "testpass"})
@@ -45,7 +45,7 @@ class TestBasicAuthExamples:
             expected_password="testpass",
         )
 
-    def test_basic_auth_failure_scenario(self):
+    def test_basic_auth_failure_scenario(self) -> None:
         """Example of testing a Basic Auth failure scenario."""
         # Create a mock client with Basic Auth configured to fail
         client = create_mock_client(


### PR DESCRIPTION
## Summary
- add explicit `-> None` annotations to BasicAuth example tests

## Testing
- `pre-commit run --files tests/unit/client/auth_examples/test_basic_auth.py`
- `poetry run mypy tests/unit/client/auth_examples/test_basic_auth.py --disallow-untyped-defs`

------
https://chatgpt.com/codex/tasks/task_e_68668be8947c83328eeac69861529dcc