### PR TITLE
Fix client fixture typing

### DIFF
--- a/tests/unit/response_strategies/conftest.py
+++ b/tests/unit/response_strategies/conftest.py
@@ -86,6 +86,6 @@ class TestCustomStrategy(ResponseModelStrategy[TestModel]):
 
 
 @pytest.fixture
-def client():
+def client() -> MagicMock:
     """Return a mock client for testing."""
     return MagicMock()


### PR DESCRIPTION
## Summary
- type annotate the MagicMock fixture in response_strategies tests

## Testing
- `poetry run pre-commit run --files tests/unit/response_strategies/conftest.py`
- `poetry run pytest -q` *(fails: crudclient.exceptions.ApiCallError)*

------
https://chatgpt.com/codex/tasks/task_e_68668bec10d88332b1cc0cb972786ea3