### PR TITLE
Fix mypy type hints in custom auth tests

### DIFF
--- a/tests/unit/auth/test_custom_auth_failures.py
+++ b/tests/unit/auth/test_custom_auth_failures.py
@@ -15,7 +15,7 @@ from crudclient.exceptions import AuthenticationError
 def test_custom_auth_failure(mock_request: requests_mock.Mocker, basic_auth_config: ClientConfig) -> None:
     """Test handling of custom authentication failures during setup."""
 
-    def header_callback():
+    def header_callback() -> dict[str, str]:
         """Simulate a failure during header generation."""
         raise ValueError("Failed to generate custom header")
 
@@ -33,7 +33,7 @@ def test_custom_auth_failure(mock_request: requests_mock.Mocker, basic_auth_conf
 def test_custom_auth_param_callback_failure(mock_request: requests_mock.Mocker, basic_auth_config: ClientConfig) -> None:
     """Test that exceptions from param_callback are propagated."""
 
-    def failing_param_callback() -> dict:
+    def failing_param_callback() -> dict[str, str]:
         raise ValueError("Failed during param generation")
 
     config = basic_auth_config
@@ -47,7 +47,7 @@ def test_custom_auth_param_callback_failure(mock_request: requests_mock.Mocker, 
 def test_custom_auth_api_failure(mock_request: requests_mock.Mocker, basic_auth_config: ClientConfig) -> None:
     """Test handling of API returning 401/403 with CustomAuth."""
 
-    def get_headers():
+    def get_headers() -> dict[str, str]:
         return {"X-Custom": "valid"}
 
     config = basic_auth_config


### PR DESCRIPTION
## Summary
- specify return types for callbacks in CustomAuth tests

## Testing
- `poetry run isort --check --profile black .`
- `poetry run black --check .`
- `poetry run flake8`
- `poetry run mypy`
- `poetry run pytest -q` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68668bea85508332a9d1649a643f0791