### PR TITLE
Update basic auth test typing

### DIFF
--- a/tests/unit/auth/test_basic_auth_failures.py
+++ b/tests/unit/auth/test_basic_auth_failures.py
@@ -6,11 +6,13 @@ from typing import cast
 
 import pytest
 import requests
+import requests_mock
 
+from crudclient.client import Client
 from crudclient.exceptions import AuthenticationError
 
 
-def test_basic_auth_failure(basic_auth_client, mock_request):
+def test_basic_auth_failure(basic_auth_client: Client, mock_request: requests_mock.Mocker) -> None:
     """Test handling of Basic Authentication failures."""
     url = f"{basic_auth_client.base_url}/users"
     mock_request.get(url, status_code=401, json={"error": "Unauthorized", "message": "Invalid credentials"})


### PR DESCRIPTION
## Summary
- import `requests_mock` and `Client`
- add type hints to `test_basic_auth_failure`

## Testing
- `poetry run pre-commit run --files tests/unit/auth/test_basic_auth_failures.py`

------
https://chatgpt.com/codex/tasks/task_e_68668dd0f9d0833298bd6c2cb8f615a2