### PR TITLE
Fix typing for mock_json

### DIFF
--- a/tests/unit/http/test_http_logging_completion.py
+++ b/tests/unit/http/test_http_logging_completion.py
@@ -1,6 +1,7 @@
 """Unit tests for HttpLifecycleLogger request completion logging."""
 
 import json as json_lib
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,7 +36,7 @@ def mock_response(mock_prepared_request: MagicMock) -> MagicMock:
     response.elapsed.total_seconds.return_value = 0.555
     response.text = response._content.decode("utf-8")
 
-    def mock_json():
+    def mock_json() -> Any:
         return json_lib.loads(response.text)  # noqa: E704
 
     response.json = mock_json


### PR DESCRIPTION
## Summary
- update unit test import order and add `Any`
- type the mock JSON fixture

## Testing
- `poetry run mypy tests/unit/http/test_http_logging_completion.py`
- `poetry run pre-commit run --files tests/unit/http/test_http_logging_completion.py`


------
https://chatgpt.com/codex/tasks/task_e_68668df15bac8332bcd100dc05214649