### PR TITLE
Fix test typing for mock_json

### DIFF
--- a/tests/unit/http/test_http_logging_error.py
+++ b/tests/unit/http/test_http_logging_error.py
@@ -2,6 +2,7 @@
 
 import json as json_lib
 import logging
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,7 +37,7 @@ def mock_response(mock_prepared_request: MagicMock) -> MagicMock:
     response.elapsed.total_seconds.return_value = 0.1
     response.text = response._content.decode("utf-8")
 
-    def mock_json():
+    def mock_json() -> Any:
         return json_lib.loads(response.text)  # noqa: E704
 
     response.json = mock_json


### PR DESCRIPTION
## Summary
- import `Any` in `test_http_logging_error`
- annotate `mock_json` with `Any`

## Testing
- `poetry run mypy tests/unit/http/test_http_logging_error.py`
- `poetry run pre-commit run --files tests/unit/http/test_http_logging_error.py`


------
https://chatgpt.com/codex/tasks/task_e_68668ded7c6083329b295a14915798a6