### PR TITLE
Update mock_client fixture to specify request type

### DIFF
--- a/tests/unit/fixtures/mock_clients.py
+++ b/tests/unit/fixtures/mock_clients.py
@@ -5,6 +5,7 @@ Fixtures related to creating various mock clients for testing.
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import pytest
+from pytest import FixtureRequest
 
 from crudclient.config import ClientConfig
 from crudclient.testing.core.client import MockClient
@@ -68,7 +69,7 @@ def create_mock_client(create_mock_client_config: Callable[..., ClientConfig]) -
 
 
 @pytest.fixture
-def mock_client(request) -> MockClient:
+def mock_client(request: FixtureRequest) -> MockClient:
     """
     Provides a pre-configured mock client for testing.
 


### PR DESCRIPTION
## Summary
- import `FixtureRequest` and type the `mock_client` fixture param

## Testing
- `poetry run mypy tests/unit/fixtures/mock_clients.py`
- `poetry run pre-commit run --files tests/unit/fixtures/mock_clients.py`


------
https://chatgpt.com/codex/tasks/task_e_68668dee3c908332ab6949e5562bfbce