### PR TITLE
Fix response handler test typing

### DIFF
--- a/tests/unit/http/test_response_handler.py
+++ b/tests/unit/http/test_response_handler.py
@@ -4,13 +4,14 @@ from unittest.mock import MagicMock
 
 import pytest
 import requests
+from pytest_mock import MockerFixture
 from requests import exceptions as requests_exceptions  # Import requests exceptions
 
 from crudclient.exceptions import ResponseParsingError
 from crudclient.http.response import ResponseHandler
 
 
-def test_response_parsing_error(mocker, caplog: pytest.LogCaptureFixture) -> None:
+def test_response_parsing_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     """Test that ResponseParsingError is raised for invalid JSON responses."""
     # Arrange
     handler = ResponseHandler()


### PR DESCRIPTION
## Summary
- import `MockerFixture` from `pytest_mock`
- type the `mocker` parameter in `test_response_parsing_error`

## Testing
- `poetry run mypy tests/unit/http/test_response_handler.py`
- `poetry run pre-commit run --files tests/unit/http/test_response_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68668def84a88332a2abfb3d38b74180