### PR TITLE
Add typed returns for unit test fixtures

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@ Fixtures specific to unit tests.
 """
 
 import uuid
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, Iterator, Optional, Type
 from unittest.mock import MagicMock  # Add MagicMock import
 
 import pytest
@@ -116,7 +116,7 @@ def mock_client_config() -> MagicMock:
 
 
 @pytest.fixture
-def requests_mocker():
+def requests_mocker() -> Iterator[requests_mock.Mocker]:
     """Provide a requests mocker for HTTP request mocking."""
     with requests_mock.Mocker() as m:
         yield m
@@ -279,7 +279,7 @@ def mock_api_error() -> Type[APIError]:
 
 # --- Enhanced Mock Client Fixtures ---
 @pytest.fixture
-def api_pattern_builder():
+def api_pattern_builder() -> Type[APIPatternBuilder]:
     """
     Provides the APIPatternBuilder class for creating API patterns.
     """
@@ -287,7 +287,7 @@ def api_pattern_builder():
 
 
 @pytest.fixture
-def response_builder():
+def response_builder() -> Type[ResponseBuilder]:
     """
     Provides the ResponseBuilder class for creating complex responses.
     """
@@ -295,7 +295,7 @@ def response_builder():
 
 
 @pytest.fixture
-def request_verifier():
+def request_verifier() -> Type[Verifier]:
     """
     Provides the RequestVerifier class for verifying API requests.
     """
@@ -303,7 +303,7 @@ def request_verifier():
 
 
 @pytest.fixture
-def response_verifier():
+def response_verifier() -> Type[Verifier]:
     """
     Provides the ResponseVerifier class for verifying API responses.
     """


### PR DESCRIPTION
## Summary
- provide return type for the `requests_mocker` fixture
- type annotate builder fixtures
- ensure imports include `Iterator`

## Testing
- `poetry run pre-commit run --files tests/unit/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_68668db7d4488332aa9d5ba2f9d99720