### PR TITLE
Add type hints to TestClient methods

### DIFF
--- a/tests/unit/client/test_client_data.py
+++ b/tests/unit/client/test_client_data.py
@@ -1,8 +1,10 @@
-from typing import Any, Callable
+from typing import Any, Callable, Self
 from unittest.mock import MagicMock
 
 import pytest
 import requests
+import requests_mock
+from pytest_mock import MockerFixture
 
 from crudclient.client import Client
 
@@ -11,7 +13,7 @@ from crudclient.client import Client
 
 class TestClient:
 
-    def test_prepare_data_sets_json_content_type(self, client: Client) -> None:
+    def test_prepare_data_sets_json_content_type(self: Self, client: Client) -> None:
         # Arrange
         json_data = {"a": 1}
 
@@ -25,7 +27,7 @@ class TestClient:
         assert headers["Content-Type"] == "application/json"
         assert client.session.headers["Content-Type"] == "application/json"
 
-    def test_prepare_data_sets_files_content_type(self, client: Client) -> None:
+    def test_prepare_data_sets_files_content_type(self: Self, client: Client) -> None:
         # Arrange
         files_data = {"file": b"abc"}
         form_data = {"name": "test"}
@@ -41,7 +43,7 @@ class TestClient:
         assert headers["Content-Type"] == "multipart/form-data"
         assert client.session.headers["Content-Type"] == "multipart/form-data"
 
-    def test_prepare_data_sets_form_content_type(self, client: Client) -> None:
+    def test_prepare_data_sets_form_content_type(self: Self, client: Client) -> None:
         # Arrange
         form_data = {"a": "b"}
 
@@ -55,7 +57,7 @@ class TestClient:
         assert headers["Content-Type"] == "application/x-www-form-urlencoded"
         assert client.session.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
-    def test_prepare_data_empty(self, client: Client) -> None:
+    def test_prepare_data_empty(self: Self, client: Client) -> None:
         # Arrange
 
         # Act
@@ -65,7 +67,7 @@ class TestClient:
         assert headers == {}
         assert data == {}
 
-    def test_maybe_retry_after_403_should_retry(self, client: Client, mock_request, mocker) -> None:
+    def test_maybe_retry_after_403_should_retry(self: Self, client: Client, mock_request: requests_mock.Mocker, mocker: MockerFixture) -> None:
         # Arrange
         # Mock config to allow retry
         client.config.should_retry_on_403 = lambda: True  # type: ignore[assignment]
@@ -84,7 +86,7 @@ class TestClient:
         assert retried.status_code == 200 or retried.text == "retried"
         assert client.config.handle_403_retry.called
 
-    def test_maybe_retry_after_403_should_not_retry(self, client: Client, mock_request, mocker) -> None:
+    def test_maybe_retry_after_403_should_not_retry(self: Self, client: Client, mock_request: requests_mock.Mocker, mocker: MockerFixture) -> None:
         # Arrange
         client.config.should_retry_on_403 = lambda: False  # type: ignore[assignment]
         client.config.handle_403_retry = MagicMock(spec=Callable[..., Any])  # type: ignore[assignment]
@@ -100,7 +102,7 @@ class TestClient:
         assert result.status_code == 403
         client.config.handle_403_retry.assert_not_called()
 
-    def test_maybe_retry_after_403_no_403(self, client: Client, mock_request, mocker) -> None:
+    def test_maybe_retry_after_403_no_403(self: Self, client: Client, mock_request: requests_mock.Mocker, mocker: MockerFixture) -> None:
         # Arrange
         client.config.handle_403_retry = MagicMock(spec=Callable[..., Any])  # type: ignore[assignment]
         url = "https://example.com/resource"
@@ -114,7 +116,7 @@ class TestClient:
         assert result.status_code == 200
         client.config.handle_403_retry.assert_not_called()
 
-    def test_handle_response_octet_stream(self, client: Client, mock_request) -> None:
+    def test_handle_response_octet_stream(self: Self, client: Client, mock_request: requests_mock.Mocker) -> None:
         # Arrange
         url = "https://example.com/resource"
         content = b"\x00\x01\x02"
@@ -128,7 +130,7 @@ class TestClient:
         assert isinstance(result, bytes)
         assert result == content
 
-    def test_handle_response_multipart(self, client: Client, mock_request) -> None:
+    def test_handle_response_multipart(self: Self, client: Client, mock_request: requests_mock.Mocker) -> None:
         # Arrange
         url = "https://example.com/upload"
         content = b'--boundary\r\nContent-Disposition: form-data; name="file"; filename="test.txt"\r\n'
@@ -142,7 +144,7 @@ class TestClient:
         assert isinstance(result, bytes)
         assert result == content
 
-    def test_handle_error_response_value_error(self, client: Client, mocker) -> None:
+    def test_handle_error_response_value_error(self: Self, client: Client, mocker: MockerFixture) -> None:
         # Arrange
         from crudclient.exceptions import CrudClientError
 
@@ -162,7 +164,7 @@ class TestClient:
         assert "500" in str(excinfo.value)
         assert "raw text error" in str(excinfo.value)
 
-    def test_handle_error_response_no_http_error(self, client: Client, mocker) -> None:
+    def test_handle_error_response_no_http_error(self: Self, client: Client, mocker: MockerFixture) -> None:
         # Arrange
         from crudclient.exceptions import CrudClientError
 
@@ -190,12 +192,12 @@ class TestClient:
             ("GET", "https://example.com", {}, object(), "response must be a requests.Response object"),
         ],
     )
-    def test_maybe_retry_after_403_type_errors(self, client: Client, method, url, kwargs, response, expected) -> None:
+    def test_maybe_retry_after_403_type_errors(self: Self, client: Client, method: Any, url: Any, kwargs: Any, response: Any, expected: str) -> None:
         """_maybe_retry_after_403 should validate argument types."""
         with pytest.raises(TypeError, match=expected):
             client._maybe_retry_after_403(method, url, kwargs, response)
 
-    def test_maybe_retry_after_403_calls_setup_auth(self, client: Client, mocker) -> None:
+    def test_maybe_retry_after_403_calls_setup_auth(self: Self, client: Client, mocker: MockerFixture) -> None:
         """_maybe_retry_after_403 should refresh auth before retrying."""
         client.config.should_retry_on_403 = lambda: True  # type: ignore[assignment]
         mocker.patch.object(client.config, "handle_403_retry")


### PR DESCRIPTION
## Summary
- annotate `TestClient` methods with type hints
- run `pre-commit` on updated test file

## Testing
- `poetry run pre-commit run --files tests/unit/client/test_client_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68668db539548332b64c78514b216413