### PR TITLE
fix(types): resolve MyPy inheritance and union type errors across CRUD library

### DIFF
--- a/crudclient/crud/base.py
+++ b/crudclient/crud/base.py
@@ -33,6 +33,7 @@ from ..response_strategies import (
     PathBasedResponseModelStrategy,
     ResponseModelStrategy,
 )
+from ..types import JSONDict, JSONList
 
 # Get a logger for this module
 logger = logging.getLogger(__name__)
@@ -160,15 +161,8 @@ class Crud(Generic[T]):
     from .endpoint import _join_path_segments  # type: ignore
     from .endpoint import _validate_path_segments  # type: ignore
 
-    # --- Operations Methods ---
+    # --- Operations Helper Methods ---
     from .operations import _prepare_request_body_kwargs  # type: ignore
-    from .operations import create  # type: ignore
-    from .operations import custom_action  # type: ignore
-    from .operations import destroy  # type: ignore
-    from .operations import list  # type: ignore
-    from .operations import partial_update  # type: ignore
-    from .operations import read  # type: ignore
-    from .operations import update  # type: ignore
 
     # --- Response Conversion Methods ---
     from .response_conversion import _convert_to_list_model  # type: ignore
@@ -181,6 +175,74 @@ class Crud(Generic[T]):
     from .response_conversion import _validate_list_return  # type: ignore
     from .response_conversion import _validate_partial_dict  # type: ignore
     from .response_conversion import _validate_response  # type: ignore
+
+    # --- Operations Methods (defined as proper methods for type checking) ---
+    def list(
+        self, parent_id: Optional[str] = None, params: Optional["JSONDict"] = None, **kwargs: Any
+    ) -> Union["JSONList", List[T], "ListResponseWrapper[T]"]:
+        """Retrieve a list of resources."""
+        from .operations import list_operation
+
+        return list_operation(self, parent_id, params, **kwargs)
+
+    def create(
+        self, data: Union["JSONDict", T], parent_id: Optional[str] = None, params: Optional["JSONDict"] = None, **kwargs: Any
+    ) -> Union[T, "JSONDict"]:
+        """Create a new resource."""
+        from .operations import create_operation
+
+        return create_operation(self, data, parent_id, params, **kwargs)
+
+    def read(self, resource_id: str, parent_id: Optional[str] = None, params: Optional["JSONDict"] = None, **kwargs: Any) -> Union[T, "JSONDict"]:
+        """Retrieve a single resource."""
+        from .operations import read_operation
+
+        return read_operation(self, resource_id, parent_id, **kwargs)
+
+    def update(
+        self,
+        resource_id: Optional[str] = None,
+        data: Optional[Union["JSONDict", T]] = None,
+        parent_id: Optional[str] = None,
+        update_mode: Optional[str] = None,
+        params: Optional["JSONDict"] = None,
+        **kwargs: Any,
+    ) -> Union[T, "JSONDict"]:
+        """Update an existing resource."""
+        from .operations import update_operation
+
+        return update_operation(self, resource_id, data, parent_id, update_mode, params, **kwargs)
+
+    def partial_update(
+        self, resource_id: str, data: Union["JSONDict", T], parent_id: Optional[str] = None, params: Optional["JSONDict"] = None, **kwargs: Any
+    ) -> Union[T, "JSONDict"]:
+        """Partially update an existing resource."""
+        from .operations import partial_update_operation
+
+        return partial_update_operation(self, resource_id, data, parent_id, params, **kwargs)
+
+    def destroy(self, resource_id: str, parent_id: Optional[str] = None, params: Optional["JSONDict"] = None, **kwargs: Any) -> None:
+        """Delete a resource."""
+        from .operations import destroy_operation
+
+        return destroy_operation(self, resource_id, parent_id, params, **kwargs)
+
+    def custom_action(
+        self,
+        action: str,
+        method: str = "post",
+        resource_id: Optional[str] = None,
+        parent_id: Optional[str] = None,
+        data: Optional[Union["JSONDict", T]] = None,
+        params: Optional["JSONDict"] = None,
+        files: Optional["JSONDict"] = None,
+        content_type: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Union[T, "JSONDict", List["JSONDict"], "ListResponseWrapper[T]"]:
+        """Perform a custom action on the resource."""
+        from .operations import custom_action_operation
+
+        return custom_action_operation(self, action, method, resource_id, parent_id, data, params, files, content_type, **kwargs)
 
 
 # Alias for backward compatibility

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,27 +25,19 @@ warn_unreachable = true
 [mypy-apiconfig.*]
 ignore_missing_imports = true
 
-# Example of per-module override:
-# [mypy-tests.integration.oneflow_resources.setup]
-# ignore_errors = true
-# disable_error_code = assignment, override, return-value, call-overload, index
-
-# Exclude test files from strict typing requirements
-[mypy-tests.*]
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-check_untyped_defs = false
-
 # Ignore specific errors
 # Ignore integration test issues for now
 # These would need to be fixed properly in a real project, but for this task
 # we'll focus on the core library code
 [mypy-tests.integration.*]
-ignore_errors = true
+ignore_errors = false
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false
 
 # Exception: These files have been fixed for typing issues
-# [mypy-tests.integration.tripletex_resources.models.supplier]
-# ignore_errors = false
+[mypy-tests.integration.tripletex_resources.models.supplier]
+ignore_errors = false
 
 [mypy-tests.integration.fiken_resources.models]
 ignore_errors = false

--- a/tests/integration/oneflow_resources/setup.py
+++ b/tests/integration/oneflow_resources/setup.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from dotenv import load_dotenv
 
@@ -59,7 +59,20 @@ class OneflowDataFields(Crud[DataField]):
     _methods: List[str] = ["update", "destroy"]
     _parent_resource = OneflowTemplateTypes
 
-    def update(self, resource_id: str, data: Dict[str, Any] | DataField, parent_id: str | None = None) -> DataField | JSONDict:
+    def update(
+        self,
+        resource_id: Optional[str] = None,
+        data: Optional[Dict[str, Any] | DataField] = None,
+        parent_id: Optional[str] = None,
+        update_mode: Optional[str] = None,
+        params: Optional[JSONDict] = None,
+        **kwargs: Any,
+    ) -> Union[DataField, JSONDict]:
+        # OneFlow API requires these parameters, so validate them
+        if resource_id is None:
+            raise ValueError("Resource id is required for updating data fields")
+        if data is None:
+            raise ValueError("Data is required for updating data fields")
         if parent_id is None:
             raise ValueError("Parent id is required for updating data fields")
 

--- a/tests/integration/tripletex_resources/crud.py
+++ b/tests/integration/tripletex_resources/crud.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Optional, Type, TypeVar, Union
+from typing import ClassVar, Generic, Optional, Type, TypeVar, Union, cast
 
 from crudclient.crud import Crud
 from crudclient.groups import ResourceGroup
@@ -10,22 +10,7 @@ from .models.api_response_model import TripletexResponse
 T = TypeVar("T", bound=ModelDumpable)
 
 
-class TripletexMixin:
-    """
-    Mixin class for Tripletex-specific configurations.
-
-    This mixin provides common Tripletex API configurations that are shared
-    between both TripletexCrud and TripletexResourceGroup.
-    """
-
-    # Set API-level response wrapper for all Tripletex list operations
-    _api_response_model: Type[Any] = TripletexResponse
-
-    # Tripletex uses 'values' for list data
-    _list_return_keys = ["values", "data", "results", "items"]
-
-
-class TripletexCrud(TripletexMixin, Crud[T], Generic[T]):
+class TripletexCrud(Crud[T], Generic[T]):
     """
     Base class for Tripletex CRUD operations.
 
@@ -34,9 +19,15 @@ class TripletexCrud(TripletexMixin, Crud[T], Generic[T]):
     'value' field and lists in a 'values' field.
     """
 
+    # Set API-level response wrapper for all Tripletex list operations
+    _api_response_model: ClassVar[Type[TripletexResponse]] = TripletexResponse
+
+    # Tripletex uses 'values' for list data
+    _list_return_keys = ["values", "data", "results", "items"]
+
     # Override these attributes to allow for different model types
-    _create_model: Optional[Type[Any]] = None
-    _update_model: Optional[Type[Any]] = None
+    _create_model: ClassVar[Optional[Type[ModelDumpable]]] = None
+    _update_model: ClassVar[Optional[Type[ModelDumpable]]] = None
 
     def _convert_to_model(self, data: RawResponse) -> Union[T, JSONDict]:
         """
@@ -84,14 +75,15 @@ class TripletexCrud(TripletexMixin, Crud[T], Generic[T]):
             value_data = validated_data["value"]
             if isinstance(value_data, dict):
                 return self._datamodel(**value_data)
-            return value_data
+            # If value_data is not a dict, it should be a JSONDict or the model type T
+            return cast(Union[T, JSONDict], value_data)
 
         # Fall back to parent class behavior for other cases
         # List responses are handled by _validate_list_return, not this method
-        return super()._convert_to_model(validated_data)
+        return cast(Union[T, JSONDict], super()._convert_to_model(validated_data))
 
 
-class TripletexResourceGroup(TripletexMixin, ResourceGroup[T], Generic[T]):
+class TripletexResourceGroup(ResourceGroup[T], TripletexCrud[T], Generic[T]):
     """
     Base class for Tripletex ResourceGroup operations.
 

--- a/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/historical.py
+++ b/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/historical.py
@@ -1,12 +1,9 @@
-from typing import Optional, Union, cast
+from typing import Optional, cast
 
 from crudclient.types import JSONDict
 
 from ....crud import TripletexCrud
-from ....models import (
-    HistoricalVoucher,
-    HistoricalVoucherResponse,
-)
+from ....models import HistoricalVoucher, TripletexResponse
 from ....utils import ensure_date_params
 
 
@@ -20,10 +17,9 @@ class TripletexHistoricalVoucherCrud(TripletexCrud[HistoricalVoucher]):
 
     _resource_path = "historical"
     _datamodel = HistoricalVoucher
-    _api_response_model = HistoricalVoucherResponse
     allowed_actions = ["list", "read", "create"]
 
-    def list(self, parent_id: Optional[str] = None, params: Optional[JSONDict] = None, **kwargs) -> HistoricalVoucherResponse:
+    def list(self, parent_id: Optional[str] = None, params: Optional[JSONDict] = None, **kwargs) -> TripletexResponse[HistoricalVoucher]:
         """
         List all historical vouchers.
 
@@ -40,19 +36,4 @@ class TripletexHistoricalVoucherCrud(TripletexCrud[HistoricalVoucher]):
 
         # Call the parent list method with the updated params
         result = super().list(parent_id=parent_id, params=params, **kwargs)
-        return cast(HistoricalVoucherResponse, result)
-
-    def create(self, data: Union[dict, JSONDict], parent_id: Optional[str] = None, **kwargs) -> HistoricalVoucher:
-        """
-        Create a new historical voucher.
-
-        Args:
-            data: The data for the new historical voucher.
-            parent_id: Optional parent ID if this is a nested resource.
-            **kwargs: Additional parameters.
-
-        Returns:
-            The created HistoricalVoucher object.
-        """
-        result = super().create(data, parent_id=parent_id, **kwargs)
-        return cast(HistoricalVoucher, result)
+        return cast(TripletexResponse[HistoricalVoucher], result)

--- a/tests/integration/tripletex_resources/endpoints/suppliers.py
+++ b/tests/integration/tripletex_resources/endpoints/suppliers.py
@@ -1,4 +1,4 @@
-from typing import List, Type
+from typing import ClassVar, List, Type
 
 from crudclient.response_strategies.base import ModelDumpable
 
@@ -29,6 +29,6 @@ class TripletexSuppliers(TripletexCrud[Supplier]):
 
     _resource_path = "supplier"
     _datamodel = Supplier  # Base model for type hints and API responses
-    _create_model: Type[ModelDumpable] = SupplierCreate  # Model for create operations
-    _update_model: Type[ModelDumpable] = SupplierUpdate  # Model for update operations
+    _create_model: ClassVar[Type[ModelDumpable]] = SupplierCreate  # Model for create operations
+    _update_model: ClassVar[Type[ModelDumpable]] = SupplierUpdate  # Model for update operations
     allowed_actions: List[str] = ["list", "read", "create", "update", "destroy"]

--- a/tests/integration/tripletex_resources/models/__init__.py
+++ b/tests/integration/tripletex_resources/models/__init__.py
@@ -18,7 +18,6 @@ from .company import Company
 from .country import Country
 from .ledger import (
     HistoricalVoucher,
-    HistoricalVoucherResponse,
     Ledger,
     LedgerResponse,
     Voucher,

--- a/tests/integration/tripletex_resources/models/ledger.py
+++ b/tests/integration/tripletex_resources/models/ledger.py
@@ -120,12 +120,3 @@ class HistoricalVoucher(BaseModel):
     postings: Optional[List[dict]] = None
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")
-
-
-class HistoricalVoucherResponse(TripletexResponse[HistoricalVoucher]):
-    """
-    Response model for historical voucher endpoints.
-    """
-
-    # The data field is already defined in the parent class with proper aliases
-    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra="ignore")

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -220,7 +220,7 @@ class TestAPI:
         assert update_response == {"id": 4, "name": "updated"}
 
         # Act & Assert - Delete operation
-        delete_response = api.test_resource.destroy("4")
+        delete_response: None = api.test_resource.destroy("4")  # type: ignore[func-returns-value]
         assert delete_response is None
 
     def test_custom_action(self, default_mock_client_config: Any, requests_mocker: Any, standard_data: Any) -> None:

--- a/tests/unit/crud/test_crud_with_simple_mock.py
+++ b/tests/unit/crud/test_crud_with_simple_mock.py
@@ -1,7 +1,7 @@
 """Tests for CRUD operations using a real client and HTTPServer."""
 
 import json
-from typing import Any
+from typing import Any, List, cast
 
 from apiconfig.testing.integration.servers import (
     assert_request_received,
@@ -10,6 +10,8 @@ from apiconfig.testing.integration.servers import (
     configure_mock_response as _configure_mock_response,
 )
 from pytest_httpserver import HTTPServer
+
+from crudclient.models import ListResponseWrapper
 
 from .conftest import BaseTestCrud, BaseTestModel
 
@@ -59,16 +61,21 @@ def test_list_operation_success(
 
     # Call the list operation
     result = base_test_crud_httpserver.list()
-    if hasattr(result, "data"):
-        result = result.data
+
+    # Handle different return types from list operation
+    if isinstance(result, ListResponseWrapper):
+        result_list = result.data
+    else:
+        # result is either JSONList or List[BaseTestModel]
+        result_list = cast(List[BaseTestModel], result)
 
     # Verify the result
-    assert len(result) == 2
-    assert all(isinstance(item, BaseTestModel) for item in result)
-    assert result[0].id == 1
-    assert result[0].name == "Resource 1"
-    assert result[1].id == 2
-    assert result[1].name == "Resource 2"
+    assert len(result_list) == 2
+    assert all(isinstance(item, BaseTestModel) for item in result_list)
+    assert result_list[0].id == 1
+    assert result_list[0].name == "Resource 1"
+    assert result_list[1].id == 2
+    assert result_list[1].name == "Resource 2"
 
     # Verify the request
     assert_request_received(httpserver, "/test-resources", method="GET")

--- a/tests/unit/crud/test_custom_actions.py
+++ b/tests/unit/crud/test_custom_actions.py
@@ -131,11 +131,11 @@ def test_custom_action_type_error(base_test_crud: BaseTestCrud) -> None:
     """
     # GIVEN / WHEN / THEN
     with pytest.raises(TypeError, match="Action must be a string"):
-        base_test_crud.custom_action(action=123)
+        base_test_crud.custom_action(action=123)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Resource ID must be a string or None"):
-        base_test_crud.custom_action(action="test", resource_id=123)
+        base_test_crud.custom_action(action="test", resource_id=123)  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="Parent ID must be a string or None"):
-        base_test_crud.custom_action(action="test", parent_id=123)
+        base_test_crud.custom_action(action="test", parent_id=123)  # type: ignore[arg-type]
 
 
 def test_custom_action_model_conversion_error(base_test_crud: BaseTestCrud, mock_client: MagicMock) -> None:

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -202,7 +202,7 @@ class TestResourceGroupAsCrud:
         resource_id = "123"
 
         # Act
-        result = group.destroy(resource_id=resource_id)
+        result = group.destroy(resource_id=resource_id)  # type: ignore[func-returns-value]
 
         # Assert
         # Check that the client was called with the correct path


### PR DESCRIPTION
This commit addresses multiple MyPy typing issues that were preventing proper static type checking for library consumers, particularly around the declarative inheritance pattern used throughout the CRUD system.

## Key Changes:

### CRUD Base Class Method Visibility (crudclient/crud/base.py)
- Define CRUD methods (list, create, read, update, partial_update, destroy, custom_action) directly in Crud class instead of importing as functions
- Add proper type annotations and delegate to operations.py functions
- Import _prepare_request_body_kwargs to make it visible to MyPy
- Fix return type annotations (destroy: None, custom_action: Union types)

### Method Signature Compatibility (tests/integration/oneflow_resources/setup.py)
- Update OneflowDataFields.update() signature to match base Crud class
- Add proper parameter validation for OneFlow API requirements
- Use Union[DataField, JSONDict] return type annotation

### Union Type Narrowing (tests/unit/crud/test_crud_with_simple_mock.py)
- Replace hasattr() with isinstance() for proper type narrowing
- Add explicit type casting for MyPy union type resolution
- Handle ListResponseWrapper[T] vs List[T] return types correctly

### Type Cast Fixes (tests/integration/tripletex_resources/crud.py)
- Add cast() statements in _convert_to_model to resolve no-any-return errors
- Ensure return types match method signatures