### PR TITLE
Fix Tripletex company test annotations

### DIFF
--- a/tests/integration/test_tripletex_company.py
+++ b/tests/integration/test_tripletex_company.py
@@ -9,7 +9,7 @@ from .tripletex_resources import TripletexAPI, TripletexTestConfig
 
 
 @pytest.fixture
-def api():
+def api() -> TripletexAPI:
     """
     Create a Tripletex API client for testing.
     """
@@ -17,7 +17,7 @@ def api():
     return TripletexAPI(client_config=config)
 
 
-def generate_unique_name():
+def generate_unique_name() -> str:
     """
     Generate a unique name for a company to avoid conflicts in the test environment.
     """
@@ -63,3 +63,5 @@ def test_update_company_minimal(api):
 
     assert updated_company.id == updated_company2.id == read_company.id == read_company2.id
     assert updated_company2.name == read_company2.name
+
+    return None


### PR DESCRIPTION
## Summary
- annotate `api()` fixture and `generate_unique_name()`
- return `None` from `test_update_company_minimal`

## Testing
- `poetry run pre-commit run --files tests/integration/test_tripletex_company.py`

------
https://chatgpt.com/codex/tasks/task_e_68693232067883328daf2d451071d0fe