### PR TITLE
Add missing type hints to rate limiting test

### DIFF
--- a/tests/integration/test_tripletex_rate_limiting_live.py
+++ b/tests/integration/test_tripletex_rate_limiting_live.py
@@ -32,7 +32,7 @@ logging.getLogger("crudclient.ratelimit").setLevel(logging.DEBUG)
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_tripletex_rate_limiting_prevents_429():
+def test_tripletex_rate_limiting_prevents_429() -> None:
     """
     Test that rate limiter prevents 429 errors under real rate limit conditions.
 
@@ -63,7 +63,12 @@ def test_tripletex_rate_limiting_prevents_429():
     protected_results: list[tuple[str, float]] = []
     results_lock = threading.Lock()
 
-    def make_requests(api, num_requests, results_list, client_name):
+    def make_requests(
+        api: TripletexAPI,
+        num_requests: int,
+        results_list: list[tuple[str, float]],
+        client_name: str,
+    ) -> None:
         """Make requests and track results."""
         local_results = []
 
@@ -167,7 +172,7 @@ def test_tripletex_rate_limiting_prevents_429():
     reason="Skip live API rate limiting tests in CI - file-based rate limiter doesn't work across matrix jobs",
 )
 @pytest.mark.no_parallel
-def test_rate_limiter_delay_tracking():
+def test_rate_limiter_delay_tracking() -> None:
     """Test that the rate limiter delay tracking mechanism works correctly."""
 
     print("\n=== Testing rate limiter delay tracking ===")


### PR DESCRIPTION
## Summary
- annotate test functions with explicit return type
- add parameter hints for the `make_requests` helper function

## Testing
- `poetry run pre-commit run --files tests/integration/test_tripletex_rate_limiting_live.py`

------
https://chatgpt.com/codex/tasks/task_e_6869323101d08332bb53b6c0a204fcfb