### PR TITLE
Fix historical voucher list typing

### DIFF
--- a/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/historical.py
+++ b/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/historical.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 from crudclient.types import JSONDict
 
@@ -19,7 +19,7 @@ class TripletexHistoricalVoucherCrud(TripletexCrud[HistoricalVoucher]):
     _datamodel = HistoricalVoucher
     allowed_actions = ["list", "read", "create"]
 
-    def list(self, parent_id: Optional[str] = None, params: Optional[JSONDict] = None, **kwargs) -> TripletexResponse[HistoricalVoucher]:
+    def list(self, parent_id: Optional[str] = None, params: Optional[JSONDict] = None, **kwargs: Any) -> TripletexResponse[HistoricalVoucher]:
         """
         List all historical vouchers.
 


### PR DESCRIPTION
## Summary
- expand typing for historical voucher endpoint
- run pre-commit and unit tests

## Testing
- `pre-commit run --files tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/historical.py`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_686932234f2c8332824de850e37c0cac