### PR TITLE
Update fiken tests

### DIFF
--- a/tests/integration/test_fiken.py
+++ b/tests/integration/test_fiken.py
@@ -6,7 +6,7 @@ from .fiken_resources.setup import Company, Contact, FikenAPI, FikenConfig, User
 
 
 @pytest.fixture
-def api():
+def api() -> FikenAPI:
     config = FikenConfig()
     return FikenAPI(client_config=config)
 
@@ -15,7 +15,7 @@ def test_api_configuration(api) -> None:
     assert api.client.base_url == "https://api.fiken.no/api/v2"
 
     # Skip auth tests if no token is provided
-    token = os.getenv("FIKEN_ACCESS_TOKEN", "")
+    token: str = os.getenv("FIKEN_ACCESS_TOKEN", "")
     if token:
         # Check that we have an auth strategy set up
         assert api.client.config.auth_strategy is not None
@@ -28,12 +28,16 @@ def test_api_configuration(api) -> None:
         assert len(api.client.config.auth_strategy.access_token) == 43
         assert api.client.config.auth_strategy.access_token != ""
 
+    return None
+
 
 def test_retrive_user(api) -> None:
     user = api.user.read()
     assert isinstance(user, User)
     assert user.name is not None
     assert user.email is not None
+
+    return None
 
 
 def test_list_companies(api) -> None:
@@ -43,6 +47,8 @@ def test_list_companies(api) -> None:
     assert len(companies) > 0
     assert all(isinstance(company, Company) for company in companies)
 
+    return None
+
 
 def test_list_contacts(api) -> None:
     contacts = api.contacts.bind_company("fiken-demo-faktisk-plante-as2").list()
@@ -50,3 +56,5 @@ def test_list_contacts(api) -> None:
     assert len(contacts) > 0
     assert all(isinstance(contact, Contact) for contact in contacts)
     assert all(isinstance(contact, Contact) for contact in contacts)
+
+    return None


### PR DESCRIPTION
## Summary
- add return annotations for api fixture
- annotate integration tests variables and add explicit `None` returns

## Testing
- `pre-commit run --files tests/integration/test_fiken.py`

------
https://chatgpt.com/codex/tasks/task_e_6869322a59548332b44a0f785f5eb29c