### PR TITLE
Add return type to OneflowConfig init

### DIFF
--- a/tests/integration/oneflow_resources/setup.py
+++ b/tests/integration/oneflow_resources/setup.py
@@ -29,7 +29,7 @@ class OneflowConfig(ClientConfig):
     api_key = os.getenv("ONEFLOW_API_KEY")
     headers: Optional[Dict[str, str]] = {"x-oneflow-user-email": os.getenv("ONEFLOW_USER_EMAIL", "")}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         if self.api_key:
             self.auth_strategy = ApiKeyAuth(api_key=self.api_key, header_name="x-oneflow-api-token")


### PR DESCRIPTION
## Summary
- fix constructor typing in OneflowConfig

## Testing
- `pre-commit run --files tests/integration/oneflow_resources/setup.py`
- `poetry run pytest -q` *(fails: crudclient.exceptions.ClientError due to blocked network calls)*

------
https://chatgpt.com/codex/tasks/task_e_686931f92f748332a31764b8c8a9224f