### PR TITLE
Fix untyped parameter in tests

### DIFF
--- a/tests/integration/tripletex_resources/auth.py
+++ b/tests/integration/tripletex_resources/auth.py
@@ -101,7 +101,7 @@ class TripletexAuthStrategy(AuthStrategy):
         logger.debug("Created expiration date: %s", expiration_str)
         return expiration_str
 
-    def refresh_token(self, force=False) -> None:
+    def refresh_token(self, force: bool = False) -> None:
         """
         Refresh the session token.
         """


### PR DESCRIPTION
## Summary
- add explicit bool type for `force` in TripletexAuthStrategy.refresh_token

## Testing
- `poetry run pre-commit run --files tests/integration/tripletex_resources/auth.py`
- `poetry run pytest -q` *(fails: attempted network access)*

------
https://chatgpt.com/codex/tasks/task_e_686931f7e13883328e698beba3ab6eaf