### PR TITLE
Fix queue type annotation for api_worker

### DIFF
--- a/tests/integration/test_rate_limit_integration.py
+++ b/tests/integration/test_rate_limit_integration.py
@@ -4,6 +4,8 @@ Integration tests for rate limiting functionality.
 Tests the full rate limiting behavior with real HTTP clients and file storage.
 """
 
+from __future__ import annotations
+
 import multiprocessing
 import os
 import tempfile
@@ -19,7 +21,7 @@ from crudclient.ratelimit import get_rate_limiter
 def api_worker(
     worker_id: int,
     state_dir: str,
-    results_queue: multiprocessing.Queue,
+    results_queue: multiprocessing.Queue[tuple[int, int, int]],
     requests_per_worker: int = 10,
 ) -> None:
     """


### PR DESCRIPTION
## Summary
- specify the typed `results_queue` parameter for `api_worker`
- use postponed evaluation for type hints

## Testing
- `poetry run pre-commit run --files tests/integration/test_rate_limit_integration.py`
- `poetry run pytest tests/integration/test_rate_limit_integration.py -q` *(fails: Missing required tokens for authentication)*

------
https://chatgpt.com/codex/tasks/task_e_686931f842188332ba4aae7b8e6b234e