### PR TITLE
Fix LedgerGroup voucher typing

### DIFF
--- a/tests/integration/tripletex_resources/endpoints/ledger_group/group.py
+++ b/tests/integration/tripletex_resources/endpoints/ledger_group/group.py
@@ -10,6 +10,7 @@ from .voucher_group import VoucherGroup
 
 
 class LedgerGroup(TripletexResourceGroup[Ledger]):
+    voucher: VoucherGroup
     """
     ResourceGroup for Tripletex ledger operations.
 


### PR DESCRIPTION
## Summary
- add `voucher` attribute type hint in tests

## Testing
- `pre-commit run --files tests/integration/tripletex_resources/endpoints/ledger_group/group.py`
- `pytest -q` *(fails: connection to api.fiken.no, jsonplaceholder.typicode.com, api.test.oneflow.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686931f622388332b520b1adff37132f