### PR TITLE
Fix TripletexClient typing

### DIFF
--- a/tests/integration/tripletex_resources/client.py
+++ b/tests/integration/tripletex_resources/client.py
@@ -1,4 +1,7 @@
+import requests
+
 from crudclient.client import Client
+from crudclient.types import RawResponseSimple
 
 
 class TripletexClient(Client):
@@ -6,7 +9,7 @@ class TripletexClient(Client):
     Custom client for Tripletex API.
     """
 
-    def _handle_response(self, response):
+    def _handle_response(self, response: requests.Response) -> RawResponseSimple:
         """
         Handle the response from the API.
 


### PR DESCRIPTION
## Summary
- update integration Tripletex client to match base class

## Testing
- `pre-commit run --files tests/integration/tripletex_resources/client.py`
- `poetry run pytest` *(fails: CrudClientError because external endpoints are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686931f6b9b083329285cc7910f7c873