### PR TITLE
Fix mypy attribute for VoucherGroup

### DIFF
--- a/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/group.py
+++ b/tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/group.py
@@ -14,6 +14,7 @@ from .historical import (
 
 
 class VoucherGroup(ResourceGroup[Voucher]):
+    historical: TripletexHistoricalVoucherCrud
     """
     ResourceGroup for Tripletex voucher operations.
 


### PR DESCRIPTION
## Summary
- add a typed `historical` attribute to the VoucherGroup test helper

## Testing
- `pre-commit run --files tests/integration/tripletex_resources/endpoints/ledger_group/voucher_group/group.py`
- `poetry run pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_686931f5e230833288c9793f3c3ab572